### PR TITLE
Clean up CMake presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Configure
-      run: cmake "--preset=ci-ubuntu"
+      run: cmake "--preset=ci-linux"
 
     - name: Build
       run: cmake --build build --config Release -j 2
@@ -155,7 +155,7 @@ jobs:
             pip install --user -r test/python/requirements.txt
 
             echo "::group::Configure"
-            cmake "--preset=ci-lcg"
+            cmake "--preset=ci-linux-lcg"
 
             echo "::group::Build"
             cmake --build build --config Release -j 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: spell-fix
         name: check for C++ spelling errors
         language: system
-        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/dev" ./.hooks/spell-fix.sh'
+        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/" ./.hooks/spell-fix.sh'
         verbose: true
         stages: [commit]
 
@@ -13,7 +13,7 @@ repos:
       - id: format-fix
         name: check for C++ formatting errors
         language: system
-        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/dev" ./.hooks/format-fix.sh'
+        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/" ./.hooks/format-fix.sh'
         verbose: true
         stages: [commit]
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,7 +44,7 @@
       }
     },
     {
-      "name": "ci-std",
+      "name": "std",
       "description": "This preset makes sure the project actually builds with at least the specified standard",
       "hidden": true,
       "cacheVariables": {
@@ -64,51 +64,21 @@
       }
     },
     {
-      "name": "flags-appleclang",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fstack-protector-strong -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wcast-qual -Wformat=2 -Wundef -Werror=float-equal -Wshadow -Wcast-align -Wunused -Wnull-dereference -Wdouble-promotion -Wimplicit-fallthrough -Wextra-semi -Woverloaded-virtual -Wnon-virtual-dtor -Wold-style-cast"
-      }
-    },
-    {
-      "name": "flags-msvc",
-      "description": "Note that all the flags after /W4 are required for MSVC to conform to the language standard",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/sdl /guard:cf /utf-8 /diagnostics:caret /w14165 /w44242 /w44254 /w44263 /w34265 /w34287 /w44296 /w44365 /w44388 /w44464 /w14545 /w14546 /w14547 /w14549 /w14555 /w34619 /w34640 /w24826 /w14905 /w14906 /w14928 /w45038 /W4 /permissive- /volatile:iso /Zc:inline /Zc:preprocessor /Zc:enumTypes /Zc:lambda /Zc:__cplusplus /Zc:externConstexpr /Zc:throwingNew /EHsc",
-        "CMAKE_EXE_LINKER_FLAGS": "/machine:x64 /guard:cf",
-        "CMAKE_SHARED_LINKER_FLAGS": "/machine:x64 /guard:cf"
-      }
-    },
-    {
-      "name": "ci-linux",
+      "name": "linux",
       "generator": "Unix Makefiles",
       "hidden": true,
-      "inherits": ["flags-gcc-clang", "ci-std"],
+      "inherits": [
+        "flags-gcc-clang",
+        "std"
+      ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
-      "name": "ci-darwin",
-      "generator": "Unix Makefiles",
-      "hidden": true,
-      "inherits": ["flags-appleclang", "ci-std"],
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
-    },
-    {
-      "name": "ci-win64",
-      "inherits": ["flags-msvc", "ci-std"],
-      "generator": "Visual Studio 17 2022",
-      "architecture": "x64",
-      "hidden": true
-    },
-    {
-      "name": "coverage-linux",
+      "name": "coverage",
       "binaryDir": "${sourceDir}/build/coverage",
-      "inherits": "ci-linux",
+      "inherits": "linux",
       "hidden": true,
       "cacheVariables": {
         "ENABLE_COVERAGE": "ON",
@@ -120,7 +90,10 @@
     },
     {
       "name": "ci-coverage",
-      "inherits": ["coverage-linux", "dev-mode"],
+      "inherits": [
+        "coverage",
+        "dev-mode"
+      ],
       "cacheVariables": {
         "COVERAGE_HTML_COMMAND": ""
       }
@@ -128,7 +101,10 @@
     {
       "name": "ci-sanitize",
       "binaryDir": "${sourceDir}/build/sanitize",
-      "inherits": ["ci-linux", "dev-mode"],
+      "inherits": [
+        "linux",
+        "dev-mode"
+      ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Sanitize",
         "CMAKE_CXX_FLAGS_SANITIZE": "-U_FORTIFY_SOURCE -O2 -g -fsanitize=address,undefined -fsanitize-recover=address -fno-omit-frame-pointer -fno-common"
@@ -140,16 +116,32 @@
       "hidden": true
     },
     {
-      "name": "ci-macos",
-      "inherits": ["ci-build", "ci-darwin", "dev-mode"]
+      "name": "ci-linux",
+      "inherits": [
+        "ci-build",
+        "linux",
+        "clang-tidy",
+        "cppcheck",
+        "dev-mode"
+      ]
     },
     {
-      "name": "ci-ubuntu",
-      "inherits": ["ci-build", "ci-linux", "clang-tidy", "cppcheck", "dev-mode"]
+      "name": "ci-linux-lcg",
+      "inherits": [
+        "ci-build",
+        "linux",
+        "dev-mode"
+      ]
     },
     {
-      "name": "ci-lcg",
-      "inherits": ["ci-build", "ci-linux", "dev-mode"]
+      "name": "dev",
+      "binaryDir": "${sourceDir}/build",
+      "description": "Preset for development",
+      "displayName": "dev",
+      "inherits": [
+        "linux",
+        "dev-mode"
+      ]
     }
   ]
 }

--- a/HACKING.md
+++ b/HACKING.md
@@ -26,56 +26,6 @@ additions.
 You have a few options to pass `FastCaloSim_DEVELOPER_MODE` to the configure
 command, but this project prefers to use presets.
 
-As a developer, you should create a `CMakeUserPresets.json` file at the root of
-the project:
-
-```json
-{
-  "version": 2,
-  "cmakeMinimumRequired": {
-    "major": 3,
-    "minor": 14,
-    "patch": 0
-  },
-  "configurePresets": [
-    {
-      "name": "dev",
-      "binaryDir": "${sourceDir}/build/dev",
-      "inherits": ["dev-mode", "ci-<os>"],
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug"
-      }
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "dev",
-      "configurePreset": "dev",
-      "configuration": "Debug"
-    }
-  ],
-  "testPresets": [
-    {
-      "name": "dev",
-      "configurePreset": "dev",
-      "configuration": "Debug",
-      "output": {
-        "outputOnFailure": true
-      }
-    }
-  ]
-}
-```
-
-You should replace `<os>` in your newly created presets file with the name of
-the operating system you have, which may be `win64`, `linux` or `darwin`. You
-can see what these correspond to in the
-[`CMakePresets.json`](CMakePresets.json) file.
-
-`CMakeUserPresets.json` is also the perfect place in which you can put all
-sorts of things that you would otherwise want to pass to the configure command
-in the terminal.
-
 > **Note**
 > Some editors are pretty greedy with how they open projects with presets.
 > Some just randomly pick a preset and start configuring without your consent,
@@ -144,31 +94,6 @@ Runs all the examples created by the `add_example` command.
 These targets run the codespell tool on the codebase to check errors and to fix
 them respectively. Customization available using the `SPELL_COMMAND` cache
 variable.
-
-## Running tests on Windows with `BUILD_SHARED_LIBS=ON`
-
-If you are building a shared library on Windows, you must add the path to the
-DLL file to `PATH` when you want to run tests. One way you could do that is by
-using PowerShell and writing a script for it, e.g. `env.ps1` at the project
-root:
-
-```powershell
-$oldPrompt = (Get-Command prompt).ScriptBlock
-
-function prompt() { "(Debug) $(& $oldPrompt)" }
-
-$VsInstallPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -Property InstallationPath
-$Env:Path += ";$VsInstallPath\Common7\IDE;$Pwd\build\dev\Debug"
-```
-
-Then you can source this script by running `. env.ps1`. This particular
-example will only work for Debug builds.
-
-### Passing `PATH` to editors
-
-Make sure you launch your editor of choice from the console with the above
-script sourced. Look for `(Debug)` in the prompt to confirm, then run e.g.
-`code .` for VScode or `devenv .` for Visual Studio.
 
 [1]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
 [2]: https://cmake.org/download/


### PR DESCRIPTION
This pull request cleans up the usage of CMake presets, and the naming is changed to be more consisent with the usage. For local development, developers should only need to use the `dev` preset.

fyi @tong-qiu 