### PR TITLE
Fix CMake preset config

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: build/dev

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,7 @@
 build/
 cmake-build-*/
 prefix/
-.clangd
 CMakeLists.txt.user
-CMakeUserPresets.json
 compile_commands.json
 env.bat
 env.ps1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: spell-fix
         name: check for C++ spelling errors
         language: system
-        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/" ./.hooks/spell-fix.sh'
+        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/dev" ./.hooks/spell-fix.sh'
         verbose: true
         stages: [commit]
 
@@ -13,7 +13,7 @@ repos:
       - id: format-fix
         name: check for C++ formatting errors
         language: system
-        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/" ./.hooks/format-fix.sh'
+        entry: bash -c 'exec env PROJ_ROOT_DIR="$PWD" BUILD_DIR="$PWD/build/dev" ./.hooks/format-fix.sh'
         verbose: true
         stages: [commit]
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,18 +21,6 @@ cmake -S . -B build
 cmake --build build --config Release
 ```
 
-### Building with MSVC
-
-Note that MSVC by default is not standards compliant and you need to pass some
-flags to make it behave properly. See the `flags-msvc` preset in the
-[CMakePresets.json](CMakePresets.json) file for the flags and with what
-variable to provide them to CMake during configuration.
-
-### Building on Apple Silicon
-
-CMake supports building on Apple Silicon properly since 3.20.1. Make sure you
-have the [latest version][1] installed.
-
 ## Install
 
 This project doesn't require any special command-line flags to install to keep

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -132,16 +132,6 @@
         "linux",
         "dev-mode"
       ]
-    },
-    {
-      "name": "dev",
-      "binaryDir": "${sourceDir}/build",
-      "description": "Preset for development",
-      "displayName": "dev",
-      "inherits": [
-        "linux",
-        "dev-mode"
-      ]
     }
   ]
 }

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -1,0 +1,36 @@
+{
+    "version": 2,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 14,
+      "patch": 0
+    },
+    "configurePresets": [
+      {
+        "name": "dev",
+        "binaryDir": "${sourceDir}/build/dev",
+        "inherits": ["dev-mode", "linux"],
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": "Debug",
+          "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        }
+      }
+    ],
+    "buildPresets": [
+      {
+        "name": "dev",
+        "configurePreset": "dev",
+        "configuration": "Debug"
+      }
+    ],
+    "testPresets": [
+      {
+        "name": "dev",
+        "configurePreset": "dev",
+        "configuration": "Debug",
+        "output": {
+          "outputOnFailure": true
+        }
+      }
+    ]
+  }

--- a/HACKING.md
+++ b/HACKING.md
@@ -26,6 +26,51 @@ additions.
 You have a few options to pass `FastCaloSim_DEVELOPER_MODE` to the configure
 command, but this project prefers to use presets.
 
+For developers a `CMakeUserPresets.json` file is provided at the root of
+the project that defines a preset for local development `dev`:
+
+```json
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 14,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "dev",
+      "binaryDir": "${sourceDir}/build/dev",
+      "inherits": ["dev-mode", "linux"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "configuration": "Debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "dev",
+      "configurePreset": "dev",
+      "configuration": "Debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}
+```
+
+`CMakeUserPresets.json` is also the perfect place in which you can put all
+sorts of things that you would otherwise want to pass to the configure command
+in the terminal.
+
 > **Note**
 > Some editors are pretty greedy with how they open projects with presets.
 > Some just randomly pick a preset and start configuring without your consent,
@@ -94,6 +139,7 @@ Runs all the examples created by the `add_example` command.
 These targets run the codespell tool on the codebase to check errors and to fix
 them respectively. Customization available using the `SPELL_COMMAND` cache
 variable.
+
 
 [1]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
 [2]: https://cmake.org/download/


### PR DESCRIPTION
After https://github.com/jbeirer/FastCaloSim/pull/37, I realized the current cmake preset config in the repo was not entirely reproducible as it required the manual addition of the `CMakeUserPresets.json` file. To make everything work out of the box I added this one as well. User should then automatically get the `dev` preset for local development without the need of creating a preset file themselves. Furthermore, we add a `.clangd ` config file that tells clangd where to look for the `compile_commands.json` compilation database.

fyi @tong-qiu 