### PR TITLE
Rename MSG macros

### DIFF
--- a/include/FastCaloSim/Core/MLogging.h
+++ b/include/FastCaloSim/Core/MLogging.h
@@ -8,7 +8,8 @@
 
 #include <FastCaloSim/FastCaloSim_export.h>
 #include <TNamed.h>  //for ClassDef
-namespace MSG
+
+namespace FCS_MSG
 {
 enum Level
 {
@@ -22,60 +23,53 @@ enum Level
   ALWAYS,
   NUM_LEVELS
 };  // enum Level
-}  // end namespace MSG
+}  // end namespace FCS_MSG
 
 // Macro for use outside classes.
 // Use this in standalone functions or static methods.
-#define ATH_MSG_NOCLASS(logger_name, x) \
+#define FCS_MSG_NOCLASS(logger_name, x) \
   do { \
-    logger_name.msg() << logger_name.startMsg(MSG::ALWAYS, __FILE__, __LINE__) \
+    logger_name.msg() << logger_name.startMsg( \
+        FCS_MSG::ALWAYS, __FILE__, __LINE__) \
                       << x << std::endl; \
   } while (0)
-
-// Declare the class accessories in a namespace
-// namespace ISF_FCS {
-//__attribute__((unused)) static const char *LevelNames[MSG::NUM_LEVELS] = {
-//    "NIL", "VERBOSE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL", "ALWAYS"};
-//} // end namespace ISF_FCS
-
-// Declare the class in a namespace
+   // Declare the class in a namespace
 namespace ISF_FCS
 {
-
-// We can define a number of macros here to replace standard ATH_MSG
+// We can define a number of macros here to replace standard FCS_MSG
 // macros. This can only be done outside Athena or the compiler complains.
 typedef std::ostream MsgStream;
 
-#define ATH_MSG_LVL(enum_lvl, x) \
+#define FCS_MSG_LVL(enum_lvl, x) \
   do { \
     if (this->msgLvl(enum_lvl)) \
       this->msg() << this->startMsg(enum_lvl, __FILE__, __LINE__) << x \
                   << std::endl; \
   } while (0)
 
-#define ATH_MSG_LVL_NOCHK(enum_lvl, x) \
+#define FCS_MSG_LVL_NOCHK(enum_lvl, x) \
   do { \
     this->msg() << this->startMsg(enum_lvl, __FILE__, __LINE__) << x \
                 << std::endl; \
   } while (0)
 
-#define ATH_MSG_VERBOSE(x) ATH_MSG_LVL(MSG::VERBOSE, x)
-#define ATH_MSG_DEBUG(x) ATH_MSG_LVL(MSG::DEBUG, x)
-#define ATH_MSG_INFO(x) ATH_MSG_LVL_NOCHK(MSG::INFO, x)
-#define ATH_MSG_WARNING(x) ATH_MSG_LVL_NOCHK(MSG::WARNING, x)
-#define ATH_MSG_ERROR(x) ATH_MSG_LVL_NOCHK(MSG::ERROR, x)
-#define ATH_MSG_FATAL(x) ATH_MSG_LVL_NOCHK(MSG::FATAL, x)
+#define FCS_MSG_VERBOSE(x) FCS_MSG_LVL(FCS_MSG::VERBOSE, x)
+#define FCS_MSG_DEBUG(x) FCS_MSG_LVL(FCS_MSG::DEBUG, x)
+#define FCS_MSG_INFO(x) FCS_MSG_LVL_NOCHK(FCS_MSG::INFO, x)
+#define FCS_MSG_WARNING(x) FCS_MSG_LVL_NOCHK(FCS_MSG::WARNING, x)
+#define FCS_MSG_ERROR(x) FCS_MSG_LVL_NOCHK(FCS_MSG::ERROR, x)
+#define FCS_MSG_FATAL(x) FCS_MSG_LVL_NOCHK(FCS_MSG::FATAL, x)
 
-// Set up a stream that can be used like: ATH_MSG(INFO) << "hello" <<
-// END_MSG(INFO); It needs to only write the left columns once, until it is fed
-// another END_MSG
+// Set up a stream that can be used like: FCS_MSG(INFO) << "hello" <<
+// END_FCS_MSG(INFO); It needs to only write the left columns once, until it is
+// fed another END_FCS_MSG
 
 // Provide a stream
-#define ATH_MSG(lvl) this->stream(MSG::lvl, __FILE__, __LINE__)
+#define FCS_MSG(lvl) this->stream(FCS_MSG::lvl, __FILE__, __LINE__)
 // Add a new line if the level is in use, and end any stream
-#define END_MSG(lvl) this->streamerEndLine(MSG::lvl)
+#define END_FCS_MSG(lvl) this->streamerEndLine(FCS_MSG::lvl)
 // Force a new line, and end any stream
-#define endmsg this->streamerEndLine(MSG::INFO)
+#define endmsg this->streamerEndLine(FCS_MSG::INFO)
 
 class FASTCALOSIM_EXPORT MLogging
 {
@@ -96,32 +90,32 @@ public:
   virtual ~MLogging() {};
 
   /// Retrieve output level
-  MSG::Level level() const { return m_level; }
+  FCS_MSG::Level level() const { return m_level; }
   /// Update outputlevel
   virtual void setLevel(int level);
 
   /// Make a message to decorate the start of logging
-  static std::string startMsg(MSG::Level lvl,
+  static std::string startMsg(FCS_MSG::Level lvl,
                               const std::string& file,
                               int line);
 
   /// Return a stream for sending messages directly (no decoration)
   MsgStream& msg() const { return *m_msg; }
   /// Return a stream for sending messages (incomplete decoration)
-  MsgStream& msg(const MSG::Level lvl) const;
+  MsgStream& msg(const FCS_MSG::Level lvl) const;
   /// Return a decorated starting stream for sending messages
-  MsgStream& stream(MSG::Level lvl, std::string file, int line) const;
+  MsgStream& stream(FCS_MSG::Level lvl, std::string file, int line) const;
   /// Check whether the logging system is active at the provided verbosity level
-  bool msgLvl(const MSG::Level lvl) const;
+  bool msgLvl(const FCS_MSG::Level lvl) const;
 
   /// Print a whole decorated log message and then end the line.
-  void print(MSG::Level lvl,
+  void print(FCS_MSG::Level lvl,
              std::string file,
              int line,
              std::string message) const;
 
   /// Update and end the line if we print this level
-  std::string streamerEndLine(MSG::Level lvl) const;
+  std::string streamerEndLine(FCS_MSG::Level lvl) const;
 
 private:
   /// Checking the state of the streamer.
@@ -129,22 +123,22 @@ private:
   /// Update if a new start is happening.
   void streamerInLine(bool is_in_line) const;
   /// Check if a new start should be done (changed file or level)
-  bool streamerNeedStart(MSG::Level lvl, std::string file) const;
+  bool streamerNeedStart(FCS_MSG::Level lvl, std::string file) const;
 
-  MSG::Level m_level = MSG::INFO;  //! Do not persistify!
+  FCS_MSG::Level m_level = FCS_MSG::INFO;  //! Do not persistify!
 
   MsgStream* m_msg = &std::cout;  //! Do not persistify!
   MsgStream m_null_msg = MsgStream(nullptr);  //! Do not persistify!
   MsgStream* m_null_msg_ptr = &m_null_msg;  //! Do not persistify!
 
   mutable bool m_streamer_in_line = false;  //! Do not persistify!
-  mutable MSG::Level m_streamer_has_lvl = MSG::NIL;  //! Do not persistify!
+  mutable FCS_MSG::Level m_streamer_has_lvl =
+      FCS_MSG::NIL;  //! Do not persistify!
   mutable std::string m_streamer_from_file = "";  //! Do not persistify!
 
   // Version number 0 to tell ROOT not to store this.
   ClassDef(MLogging, 0)
 };
-
 }  // namespace ISF_FCS
 
 #endif  // End header guard

--- a/include/FastCaloSim/Core/TFCS1DFunctionTemplateHistogram.h
+++ b/include/FastCaloSim/Core/TFCS1DFunctionTemplateHistogram.h
@@ -69,13 +69,13 @@ public:
               == m_HistoBorders.GetBinLowEdge(ihist))
           {
             if (doprint)
-              ATH_MSG_INFO("Skip bin="
+              FCS_MSG_INFO("Skip bin="
                            << ibin + 1
                            << " x=" << hist->GetXaxis()->GetBinLowEdge(ibin + 1)
                            << " fx=" << m_HistoBorders.GetBinLowEdge(ihist));
             --ihist;
             if (doprint)
-              ATH_MSG_INFO("     bin="
+              FCS_MSG_INFO("     bin="
                            << ibin
                            << " x=" << hist->GetXaxis()->GetBinLowEdge(ibin)
                            << " fx=" << m_HistoBorders.GetBinLowEdge(ihist));
@@ -87,20 +87,20 @@ public:
               == m_HistoContents.get_fraction(ihist))
           {
             if (doprint)
-              ATH_MSG_INFO("Skip fbin="
+              FCS_MSG_INFO("Skip fbin="
                            << ihist
                            << " fx=" << m_HistoBorders.GetBinLowEdge(ihist)
                            << " frac=" << m_HistoContents.get_fraction(ihist));
             --ihist;
             if (doprint)
-              ATH_MSG_INFO("     fbin="
+              FCS_MSG_INFO("     fbin="
                            << ihist
                            << " fx=" << m_HistoBorders.GetBinLowEdge(ihist)
                            << " frac=" << m_HistoContents.get_fraction(ihist));
           }
 
         if (doprint)
-          ATH_MSG_INFO("bin=" << ibin + 1 << " fbin=" << ihist << "/"
+          FCS_MSG_INFO("bin=" << ibin + 1 << " fbin=" << ihist << "/"
                               << m_HistoBorders.get_nbins() << " x=["
                               << hist->GetXaxis()->GetBinLowEdge(ibin + 1)
                               << "," << hist->GetXaxis()->GetBinUpEdge(ibin + 1)
@@ -129,7 +129,7 @@ public:
       return 0;
     Trandom residual_rnd;
     size_t ibin = m_HistoContents.get_bin(rnd, residual_rnd);
-    // ATH_MSG_INFO( fx="<<m_HistoBorders.GetBinLowEdge(ibin)<<"
+    // FCS_MSG_INFO( fx="<<m_HistoBorders.GetBinLowEdge(ibin)<<"
     // frac="<<m_HistoContents.get_fraction(ibin)<<"
     // residual_rnd="<<residual_rnd);
     return m_HistoBorders.position(ibin, residual_rnd);

--- a/include/FastCaloSim/Core/TFCS1DFunctionTemplateInterpolationHistogram.h
+++ b/include/FastCaloSim/Core/TFCS1DFunctionTemplateInterpolationHistogram.h
@@ -80,7 +80,7 @@ public:
     } else
       m = 0;
 
-    // ATH_MSG_INFO( fx="<<m_HistoBorders.GetBinLowEdge(ibin)<<"
+    // FCS_MSG_INFO( fx="<<m_HistoBorders.GetBinLowEdge(ibin)<<"
     // frac="<<m_HistoContents.get_fraction(ibin)<<" dfracprev="<<dfracprev<<"
     // dfrac="<<dfrac<<" dfracnext="<<dfracnext<<"
     // dfracprev-dfrac="<<dfracprev-dfrac<<"

--- a/include/FastCaloSim/Core/TFCS2DFunctionTemplateHistogram.h
+++ b/include/FastCaloSim/Core/TFCS2DFunctionTemplateHistogram.h
@@ -75,11 +75,11 @@ public:
             ibinx, hist->GetXaxis()->GetBinLowEdge(ibinx + 1));
         //          if(ihist>0)
         //          if(m_HistoBorders.GetBinLowEdge(ihist-1)==m_HistoBorders.GetBinLowEdge(ihist))
-        //          { ATH_MSG_INFO( bin="<<ibin+1<<"
+        //          { FCS_MSG_INFO( bin="<<ibin+1<<"
         //          x="<<hist->GetXaxis()->GetBinLowEdge(ibin+1)<<"
         //          fx="<<m_HistoBorders.GetBinLowEdge(ihist);
         //          --ihist;
-        //          ATH_MSG_INFO("     bin="<<ibin  <<"
+        //          FCS_MSG_INFO("     bin="<<ibin  <<"
         //          x="<<hist->GetXaxis()->GetBinLowEdge(ibin  )<<"
         //          fx="<<m_HistoBorders.GetBinLowEdge(ihist));
         //          }
@@ -89,11 +89,11 @@ public:
             ibiny, hist->GetYaxis()->GetBinLowEdge(ibiny + 1));
         //          if(ihist>0)
         //          if(m_HistoBorders.GetBinLowEdge(ihist-1)==m_HistoBorders.GetBinLowEdge(ihist))
-        //          { ATH_MSG_INFO("Skip bin="<<ibin+1<<"
+        //          { FCS_MSG_INFO("Skip bin="<<ibin+1<<"
         //          x="<<hist->GetXaxis()->GetBinLowEdge(ibin+1)<<"
         //          fx="<<m_HistoBorders.GetBinLowEdge(ihist));
         //          --ihist;
-        //          ATH_MSG_INFO("     bin="<<ibin  <<"
+        //          FCS_MSG_INFO("     bin="<<ibin  <<"
         //          x="<<hist->GetXaxis()->GetBinLowEdge(ibin  )<<"
         //          fx="<<m_HistoBorders.GetBinLowEdge(ihist));
         //          }
@@ -107,16 +107,16 @@ public:
           //          if(ihist>0)
           //          if(m_HistoContents.get_fraction(ihist-1)==m_HistoContents.get_fraction(ihist))
           //          {
-          //            ATH_MSG_INFO("Skip fbin="<<ihist<<"
+          //            FCS_MSG_INFO("Skip fbin="<<ihist<<"
           //            fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"
           //            frac="<<m_HistoContents.get_fraction(ihist));
           //            --ihist;
-          //            ATH_MSG_INFO("     fbin="<<ihist<<"
+          //            FCS_MSG_INFO("     fbin="<<ihist<<"
           //            fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"
           //            frac="<<m_HistoContents.get_fraction(ihist));
           //          }
 
-          //          ATH_MSG_INFO("bin="<<ibin+1<<"
+          //          FCS_MSG_INFO("bin="<<ibin+1<<"
           //          fbin="<<ihist<<"/"<<m_HistoBorders.get_nbins()<<"
           //          x=["<<hist->GetXaxis()->GetBinLowEdge(ibin+1)<<","<<hist->GetXaxis()->GetBinUpEdge(ibin+1)<<"]
           //          fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"
@@ -142,16 +142,16 @@ public:
   //          if(ihist>0)
   if(m_HistoContents.get_fraction(ihist-1)==m_HistoContents.get_fraction(ihist))
   {
-  //            ATH_MSG_INFO("Skip fbin="<<ihist<<"
+  //            FCS_MSG_INFO("Skip fbin="<<ihist<<"
   fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"
   frac="<<m_HistoContents.get_fraction(ihist));
   //            --ihist;
-  //            ATH_MSG_INFO("     fbin="<<ihist<<"
+  //            FCS_MSG_INFO("     fbin="<<ihist<<"
   fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"
   frac="<<m_HistoContents.get_fraction(ihist));
   //          }
 
-  //          ATH_MSG_INFO("bin="<<ibin+1<<"
+  //          FCS_MSG_INFO("bin="<<ibin+1<<"
   fbin="<<ihist<<"/"<<m_HistoBorders.get_nbins()<<"
   x=["<<hist->GetXaxis()->GetBinLowEdge(ibin+1)<<","<<hist->GetXaxis()->GetBinUpEdge(ibin+1)<<"]
   fx="<<m_HistoBorders.GetBinLowEdge(ihist)<<"

--- a/include/FastCaloSim/Core/TFCSGANXMLParameters.h
+++ b/include/FastCaloSim/Core/TFCSGANXMLParameters.h
@@ -51,7 +51,7 @@ private:
   int m_latentDim;
   std::string m_fastCaloGANInputFolderName;
 
-  ClassDef(TFCSGANXMLParameters, 2)  // TFCSGANXMLParameters
+  ClassDef(TFCSGANXMLParameters, 1)  // TFCSGANXMLParameters
 };
 
 #endif  //> !ISF_TFCSGANXMLPARAMETERS_H

--- a/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitChain.h
+++ b/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitChain.h
@@ -83,7 +83,7 @@ public:
   void Print(Option_t* option = "") const override;
 
 protected:
-  void PropagateMSGLevel(MSG::Level level) const;
+  void PropagateMSGLevel(FCS_MSG::Level level) const;
 
   Chain_t m_chain;
 

--- a/include/FastCaloSim/Core/TFCSParametrizationBase.h
+++ b/include/FastCaloSim/Core/TFCSParametrizationBase.h
@@ -178,7 +178,7 @@ public:
   }
 
 private:
-  ClassDef(TFCSParametrizationBase, 3)  // TFCSParametrizationBase
+  ClassDef(TFCSParametrizationBase, 4)  // TFCSParametrizationBase
 };
 
 #endif  // End header guards

--- a/include/FastCaloSim/Core/TFCSParametrizationChain.icc
+++ b/include/FastCaloSim/Core/TFCSParametrizationChain.icc
@@ -9,7 +9,7 @@ inline FCSReturnCode TFCSParametrizationChain::simulate_and_retry(
   int retry = 0;
   for (int i = 0; i <= retry; i++) {
     if (i >= retry_warning)
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "TFCSParametrizationChain::simulate_and_retry(): Retry simulate call "
           << i << "/" << retry);
 
@@ -31,7 +31,7 @@ inline FCSReturnCode TFCSParametrizationChain::simulate_and_retry(
       return status;
   }
 
-  ATH_MSG_FATAL("TFCSParametrizationChain::simulate_and_retry(): Simulate call "
+  FCS_MSG_FATAL("TFCSParametrizationChain::simulate_and_retry(): Simulate call "
                 "failed after "
                 << retry << " retries");
 

--- a/include/FastCaloSim/Core/VNetworkBase.h
+++ b/include/FastCaloSim/Core/VNetworkBase.h
@@ -307,7 +307,7 @@ protected:
 
 private:
   // Supplying a ClassDef for writing to file.
-  ClassDef(VNetworkBase, 1);
+  ClassDef(VNetworkBase, 3);
 };
 
 #endif

--- a/source/Core/MLogging.cxx
+++ b/source/Core/MLogging.cxx
@@ -9,16 +9,16 @@ namespace ISF_FCS
 /// Update outputlevel
 void MLogging::setLevel(int level)
 {
-  level = (level >= MSG::NUM_LEVELS) ? MSG::ALWAYS
-      : (level < MSG::NIL)           ? MSG::NIL
-                                     : level;
-  m_level = MSG::Level(level);
+  level = (level >= FCS_MSG::NUM_LEVELS) ? FCS_MSG::ALWAYS
+      : (level < FCS_MSG::NIL)           ? FCS_MSG::NIL
+                                         : level;
+  m_level = FCS_MSG::Level(level);
 }
 
 // startMsg defined at base of file.
 
 /// Return a stream for sending messages (incomplete decoration)
-MsgStream& MLogging::msg(const MSG::Level lvl) const
+MsgStream& MLogging::msg(const FCS_MSG::Level lvl) const
 {
   return this->stream(lvl, "", -1);
 };
@@ -28,7 +28,9 @@ MsgStream& MLogging::msg(const MSG::Level lvl) const
 // if the proposed streamer doesn't match the current one
 // end any running lines and start a new decorated line
 // provide the stream at the end
-MsgStream& MLogging::stream(MSG::Level lvl, std::string file, int line) const
+MsgStream& MLogging::stream(FCS_MSG::Level lvl,
+                            std::string file,
+                            int line) const
 {
   // If we shouldn't print this just return a dummy stream.
   if (!this->msgLvl(lvl))
@@ -45,16 +47,16 @@ MsgStream& MLogging::stream(MSG::Level lvl, std::string file, int line) const
 }
 
 /// Check whether the logging system is active at the provided verbosity level
-bool MLogging::msgLvl(const MSG::Level lvl) const
+bool MLogging::msgLvl(const FCS_MSG::Level lvl) const
 {
-  if (lvl == MSG::VERBOSE || lvl == MSG::DEBUG)
+  if (lvl == FCS_MSG::VERBOSE || lvl == FCS_MSG::DEBUG)
     return m_level <= lvl;
   // All other messages print always
   return true;
 }
 
 /// Print a whole log message and then end the line.
-void MLogging::print(MSG::Level lvl,
+void MLogging::print(FCS_MSG::Level lvl,
                      std::string file,
                      int line,
                      std::string message) const
@@ -65,7 +67,7 @@ void MLogging::print(MSG::Level lvl,
 }
 
 /// Update and end the line if we print this level
-std::string MLogging::streamerEndLine(MSG::Level lvl) const
+std::string MLogging::streamerEndLine(FCS_MSG::Level lvl) const
 {
   if (this->msgLvl(lvl)) {
     m_streamer_in_line = false;
@@ -81,7 +83,7 @@ void MLogging::streamerInLine(bool is_in_line) const
 }
 
 /// Check if a new start should be done (changed file or level)
-bool MLogging::streamerNeedStart(MSG::Level lvl, std::string file) const
+bool MLogging::streamerNeedStart(FCS_MSG::Level lvl, std::string file) const
 {
   // Are we in the middle of a stream of the same level from the same file.
   if (lvl == m_streamer_has_lvl && file == m_streamer_from_file
@@ -95,7 +97,7 @@ bool MLogging::streamerNeedStart(MSG::Level lvl, std::string file) const
 
 // This is the same either way.
 /// Print a message for the start of logging
-std::string MLogging::startMsg(MSG::Level lvl,
+std::string MLogging::startMsg(FCS_MSG::Level lvl,
                                const std::string& file,
                                int line)
 {
@@ -109,7 +111,7 @@ std::string MLogging::startMsg(MSG::Level lvl,
   if (total_len - path_len > col1_len)
     trim_point = total_len - col1_len;
   std::string trimmed_name = file.substr(trim_point);
-  const char* LevelNames[MSG::NUM_LEVELS] = {
+  const char* LevelNames[FCS_MSG::NUM_LEVELS] = {
       "NIL", "VERBOSE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL", "ALWAYS"};
   std::string level = LevelNames[lvl];
   std::string level_string = std::string("(") + level + ") ";

--- a/source/Core/TFCS1DFunction.cxx
+++ b/source/Core/TFCS1DFunction.cxx
@@ -65,7 +65,7 @@ double TFCS1DFunction::CheckAndIntegrate1DHistogram(
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
       if (TMath::Abs(fraction) > 1e-5) {
-        ATH_MSG_NOCLASS(logger,
+        FCS_MSG_NOCLASS(logger,
                         "Warning: bin content is negative in histogram "
                             << hist->GetName() << " : " << hist->GetTitle()
                             << " binval=" << binval << " " << fraction * 100
@@ -87,7 +87,7 @@ double TFCS1DFunction::CheckAndIntegrate1DHistogram(
   last++;
 
   if (integral <= 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Error: histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " integral=" << integral << " is <=0");

--- a/source/Core/TFCS1DFunctionHistogram.cxx
+++ b/source/Core/TFCS1DFunctionHistogram.cxx
@@ -106,7 +106,7 @@ void TFCS1DFunctionHistogram::smart_rebin_loop(TH1* hist, double cut_maxdev)
     maxdev *= 100.0;
 
     if (i % 100 == 0)
-      ATH_MSG_INFO("Iteration nr. " << i << " -----> change " << change
+      FCS_MSG_INFO("Iteration nr. " << i << " -----> change " << change
                                     << " bins " << h_out->GetNbinsX()
                                     << " -> maxdev=" << maxdev);
 
@@ -123,7 +123,7 @@ void TFCS1DFunctionHistogram::smart_rebin_loop(TH1* hist, double cut_maxdev)
     }
   }
 
-  ATH_MSG_INFO("Info: Rebinned histogram has " << h_output->GetNbinsX()
+  FCS_MSG_INFO("Info: Rebinned histogram has " << h_output->GetNbinsX()
                                                << " bins.");
 
   // store:

--- a/source/Core/TFCS1DFunctionInt16Histogram.cxx
+++ b/source/Core/TFCS1DFunctionInt16Histogram.cxx
@@ -30,7 +30,7 @@ void TFCS1DFunctionInt16Histogram::Initialize(const TH1* hist)
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
       if (TMath::Abs(fraction) > 1e-5) {
-        ATH_MSG_WARNING("bin content is negative in histogram "
+        FCS_MSG_WARNING("bin content is negative in histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " binval=" << binval << " " << fraction * 100
                         << "% of integral=" << hist->Integral()
@@ -43,7 +43,7 @@ void TFCS1DFunctionInt16Histogram::Initialize(const TH1* hist)
     ++ibin;
   }
   if (integral <= 0) {
-    ATH_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
+    FCS_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
                                << " integral=" << integral << " is <=0");
     m_HistoBorders.resize(0);
     m_HistoContents.resize(0);
@@ -56,7 +56,7 @@ void TFCS1DFunctionInt16Histogram::Initialize(const TH1* hist)
 
   for (ibin = 0; ibin < nbins; ++ibin) {
     m_HistoContents[ibin] = s_MaxValue * (temp_HistoContents[ibin] / integral);
-    // ATH_MSG_INFO("bin="<<ibin<<" val="<<m_HistoContents[ibin]);
+    // FCS_MSG_INFO("bin="<<ibin<<" val="<<m_HistoContents[ibin]);
   }
 }
 

--- a/source/Core/TFCS1DFunctionInt32Histogram.cxx
+++ b/source/Core/TFCS1DFunctionInt32Histogram.cxx
@@ -30,7 +30,7 @@ void TFCS1DFunctionInt32Histogram::Initialize(const TH1* hist)
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
       if (TMath::Abs(fraction) > 1e-5) {
-        ATH_MSG_WARNING("bin content is negative in histogram "
+        FCS_MSG_WARNING("bin content is negative in histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " binval=" << binval << " " << fraction * 100
                         << "% of integral=" << hist->Integral()
@@ -43,7 +43,7 @@ void TFCS1DFunctionInt32Histogram::Initialize(const TH1* hist)
     ++ibin;
   }
   if (integral <= 0) {
-    ATH_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
+    FCS_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
                                << " integral=" << integral << " is <=0");
     m_HistoBorders.resize(0);
     m_HistoContents.resize(0);

--- a/source/Core/TFCS1DFunctionSpline.cxx
+++ b/source/Core/TFCS1DFunctionSpline.cxx
@@ -21,7 +21,7 @@ double TFCS1DFunctionSpline::Initialize(TH1* hist,
   double max_penalty_best = -1;
   TSpline3 sp_best;
   for (int np = 3; np <= maxnp; ++np) {
-    ATH_MSG_INFO("========== Spline #=" << np << " ==============");
+    FCS_MSG_INFO("========== Spline #=" << np << " ==============");
     double max_penalty;
     if (max_penalty_best > 0) {
       max_penalty =
@@ -45,16 +45,16 @@ double TFCS1DFunctionSpline::Initialize(TH1* hist,
       sp_best = m_spline;
     }
 
-    ATH_MSG_INFO("========== Spline #=" << np << " max_penalty_best="
+    FCS_MSG_INFO("========== Spline #=" << np << " max_penalty_best="
                                         << max_penalty_best
                                         << " ==============");
-    ATH_MSG(INFO) << "==== Best spline init | ";
+    FCS_MSG(INFO) << "==== Best spline init | ";
     for (int i = 0; i < sp_best.GetNp(); ++i) {
       double p, x;
       sp_best.GetKnot(i, p, x);
-      ATH_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
+      FCS_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
     }
-    ATH_MSG(INFO) << " =====" << END_MSG(INFO);
+    FCS_MSG(INFO) << " =====" << END_FCS_MSG(INFO);
 
     if (max_penalty_best < 2)
       break;
@@ -84,23 +84,23 @@ double TFCS1DFunctionSpline::InitializeFromSpline(TH1* hist,
   int nsplinepoints = sp.GetNp();
   std::vector<double> nprop(nsplinepoints + 1);
   int ind = 0;
-  ATH_MSG(INFO) << "Spline init p_improve=" << p_improve << " | ";
+  FCS_MSG(INFO) << "Spline init p_improve=" << p_improve << " | ";
   for (int i = 0; i < nsplinepoints; ++i) {
     double p, x;
     sp.GetKnot(i, p, x);
     if (i == 0 && p_improve < p) {
       nprop[ind] = (0 + p) / 2;
-      ATH_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
+      FCS_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
       ++ind;
     }
 
     nprop[ind] = p;
-    ATH_MSG(INFO) << ind << " : p=" << nprop[ind] << " ; ";
+    FCS_MSG(INFO) << ind << " : p=" << nprop[ind] << " ; ";
     ++ind;
 
     if (i == nsplinepoints - 1 && p_improve > p) {
       nprop[ind] = (1 + p) / 2;
-      ATH_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
+      FCS_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
       ++ind;
     }
     if (i < nsplinepoints - 1) {
@@ -108,30 +108,30 @@ double TFCS1DFunctionSpline::InitializeFromSpline(TH1* hist,
       sp.GetKnot(i + 1, pn, xn);
       if (p_improve > p && p_improve < pn) {
         nprop[ind] = (p + pn) / 2;
-        ATH_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
+        FCS_MSG(INFO) << ind << " : pi=" << nprop[ind] << " ; ";
         ++ind;
       }
     }
   }
-  ATH_MSG(INFO) << END_MSG(INFO);
+  FCS_MSG(INFO) << END_FCS_MSG(INFO);
   nsplinepoints = ind;
   nprop.resize(nsplinepoints);
 
   double max_penalty =
       optimize(m_spline, nprop, hist, hist_fct, maxdevgoal, maxeffsiggoal);
   maxdev = get_maxdev(hist, m_spline, maxeffsig, p_maxdev, p_maxeffsig);
-  ATH_MSG_INFO("Spline init spline #=" << nsplinepoints << " : maxdev="
+  FCS_MSG_INFO("Spline init spline #=" << nsplinepoints << " : maxdev="
                                        << maxdev << " p_maxdev=" << p_maxdev
                                        << " maxeffsig=" << maxeffsig
                                        << " p_maxeffsig=" << p_maxeffsig
                                        << " max_penalty=" << max_penalty);
-  ATH_MSG(INFO) << "  ";
+  FCS_MSG(INFO) << "  ";
   for (int i = 0; i < m_spline.GetNp(); ++i) {
     double p, x;
     m_spline.GetKnot(i, p, x);
-    ATH_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
+    FCS_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
   }
-  ATH_MSG(INFO) << END_MSG(INFO);
+  FCS_MSG(INFO) << END_FCS_MSG(INFO);
   return max_penalty;
 }
 
@@ -154,7 +154,7 @@ double TFCS1DFunctionSpline::InitializeEqualDistance(TH1* hist,
     if (hist->GetBinContent(i) > 0)
       break;
   }
-  // ATH_MSG_INFO("xmin="<<xmin<<" xmax="<<xmax);
+  // FCS_MSG_INFO("xmin="<<xmin<<" xmax="<<xmax);
 
   double dx = (xmax - xmin) / (nsplinepoints - 1);
 
@@ -162,7 +162,7 @@ double TFCS1DFunctionSpline::InitializeEqualDistance(TH1* hist,
   std::vector<double> nx(nsplinepoints);
   nprop[0] = 0;
   nx[0] = hist_fct.rnd_to_fct(nprop[0]);
-  // ATH_MSG_INFO(0<<" p="<<nprop[0]<<" x="<<nx[0]);
+  // FCS_MSG_INFO(0<<" p="<<nprop[0]<<" x="<<nx[0]);
   for (int i = 1; i < nsplinepoints; ++i) {
     nx[i] = xmin + i * dx;
     double p_min = 0;
@@ -179,7 +179,7 @@ double TFCS1DFunctionSpline::InitializeEqualDistance(TH1* hist,
       if ((p_max - p_min) < 0.0000001)
         break;
     } while (TMath::Abs(tx - nx[i]) > dx / 10);
-    // ATH_MSG_INFO(i<<" p="<<p_test<<" x="<<tx);
+    // FCS_MSG_INFO(i<<" p="<<p_test<<" x="<<tx);
     nprop[i] = p_test;
   }
 
@@ -189,18 +189,18 @@ double TFCS1DFunctionSpline::InitializeEqualDistance(TH1* hist,
   double p_maxdev;
   double p_maxeffsig;
   double maxdev = get_maxdev(hist, m_spline, maxeffsig, p_maxdev, p_maxeffsig);
-  ATH_MSG_INFO("Spline init equ. dist. #=" << nsplinepoints << " : maxdev="
+  FCS_MSG_INFO("Spline init equ. dist. #=" << nsplinepoints << " : maxdev="
                                            << maxdev << " p_maxdev=" << p_maxdev
                                            << " maxeffsig=" << maxeffsig
                                            << " p_maxeffsig=" << p_maxeffsig
                                            << " max_penalty=" << max_penalty);
-  ATH_MSG(INFO) << "  ";
+  FCS_MSG(INFO) << "  ";
   for (int i = 0; i < m_spline.GetNp(); ++i) {
     double p, x;
     m_spline.GetKnot(i, p, x);
-    ATH_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
+    FCS_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
   }
-  ATH_MSG(INFO) << END_MSG(INFO);
+  FCS_MSG(INFO) << END_FCS_MSG(INFO);
   return max_penalty;
 }
 
@@ -223,18 +223,18 @@ double TFCS1DFunctionSpline::InitializeEqualProbability(TH1* hist,
   double p_maxdev;
   double p_maxeffsig;
   double maxdev = get_maxdev(hist, m_spline, maxeffsig, p_maxdev, p_maxeffsig);
-  ATH_MSG_INFO("Spline init equ. prob. #=" << nsplinepoints << " : maxdev="
+  FCS_MSG_INFO("Spline init equ. prob. #=" << nsplinepoints << " : maxdev="
                                            << maxdev << " p_maxdev=" << p_maxdev
                                            << " maxeffsig=" << maxeffsig
                                            << " p_maxeffsig=" << p_maxeffsig
                                            << " max_penalty=" << max_penalty);
-  ATH_MSG(INFO) << "  ";
+  FCS_MSG(INFO) << "  ";
   for (int i = 0; i < m_spline.GetNp(); ++i) {
     double p, x;
     m_spline.GetKnot(i, p, x);
-    ATH_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
+    FCS_MSG(INFO) << i << " : p=" << p << " x=" << x << " ; ";
   }
-  ATH_MSG(INFO) << END_MSG(INFO);
+  FCS_MSG(INFO) << END_FCS_MSG(INFO);
   return max_penalty;
 }
 
@@ -276,12 +276,12 @@ double TFCS1DFunctionSpline::optimize(TSpline3& sp_best,
         nprop = nprop_try;
         sp_best = sp;
         /*
-        ATH_MSG(INFO) <<"#="<<nsplinepoints<<" try="<<itrytot-1<<" | ";
+        FCS_MSG(INFO) <<"#="<<nsplinepoints<<" try="<<itrytot-1<<" | ";
         for(int i=0;i<nsplinepoints;++i) {
-          ATH_MSG(INFO) <<i<<":p="<<nprop_try[i]<<" x="<<nx[i]<<" ; ";
+          FCS_MSG(INFO) <<i<<":p="<<nprop_try[i]<<" x="<<nx[i]<<" ; ";
         }
-        ATH_MSG(INFO) <<"new maxdev="<<maxdev<<" maxeffsig="<<maxeffsig<<"
-        max_penalty="<<max_penalty<<END_MSG(INFO);
+        FCS_MSG(INFO) <<"new maxdev="<<maxdev<<" maxeffsig="<<maxeffsig<<"
+        max_penalty="<<max_penalty<<END_FCS_MSG(INFO);
         */
         n_nogain = 0;
       } else {
@@ -341,8 +341,8 @@ double TFCS1DFunctionSpline::get_maxdev(const TH1* hist,
   double integral = hist->IntegralAndError(1, hist->GetNbinsX(), interr);
   double effN = integral / interr;
   effN *= effN;
-  // ATH_MSG_INFO("integral="<<integral<<" +- "<<interr<<"
-  // relerr="<<interr/integral); ATH_MSG_INFO("effN="<<effN<<" +-
+  // FCS_MSG_INFO("integral="<<integral<<" +- "<<interr<<"
+  // relerr="<<interr/integral); FCS_MSG_INFO("effN="<<effN<<" +-
   // "<<TMath::Sqrt(effN)<<" relerr="<<1/TMath::Sqrt(effN));
   double toyweight = 1.0 / ntoy;
   for (int itoy = 0; itoy < ntoy; ++itoy) {
@@ -372,7 +372,7 @@ double TFCS1DFunctionSpline::get_maxdev(const TH1* hist,
       p_maxeffsig = int1;
     }
 
-    // ATH_MSG_INFO(i<<": diff="<<int1-int2<<" sig(diff)="<<valsig<<"
+    // FCS_MSG_INFO(i<<": diff="<<int1-int2<<" sig(diff)="<<valsig<<"
     // int1="<<int1<<" +- "<<int1err<<" int2="<<int2<<" maxdev="<<maxdev<<"
     // maxeffsig="<<maxeffsig);
   }

--- a/source/Core/TFCS2DFunction.cxx
+++ b/source/Core/TFCS2DFunction.cxx
@@ -42,7 +42,7 @@ double TFCS2DFunction::CheckAndIntegrate2DHistogram(
         // Can't work if a bin is negative, forcing bins to 0 in this case
         double fraction = binval / hint;
         if (TMath::Abs(fraction) > 1e-5) {
-          ATH_MSG_NOCLASS(logger,
+          FCS_MSG_NOCLASS(logger,
                           "Warning: bin content is negative in histogram "
                               << hist->GetName() << " : " << hist->GetTitle()
                               << " binval=" << binval << " " << fraction * 100
@@ -65,7 +65,7 @@ double TFCS2DFunction::CheckAndIntegrate2DHistogram(
   last++;
 
   if (integral <= 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Error: histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " integral=" << integral << " is <=0");

--- a/source/Core/TFCS2DFunctionHistogram.cxx
+++ b/source/Core/TFCS2DFunctionHistogram.cxx
@@ -29,7 +29,7 @@ void TFCS2DFunctionHistogram::Initialize(TH2* hist)
         // Can't work if a bin is negative, forcing bins to 0 in this case
         double fraction = binval / hist->Integral();
         if (TMath::Abs(fraction) > 1e-5) {
-          ATH_MSG_WARNING("bin content is negative in histogram "
+          FCS_MSG_WARNING("bin content is negative in histogram "
                           << hist->GetName() << " : " << hist->GetTitle()
                           << " binval=" << binval << " " << fraction * 100
                           << "% of integral=" << hist->Integral()
@@ -43,7 +43,7 @@ void TFCS2DFunctionHistogram::Initialize(TH2* hist)
     }
   }
   if (integral <= 0) {
-    ATH_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
+    FCS_MSG_ERROR("histogram " << hist->GetName() << " : " << hist->GetTitle()
                                << " integral=" << integral << " is <=0");
     m_HistoBorders.resize(0);
     m_HistoBordersy.resize(0);

--- a/source/Core/TFCS2DFunctionLateralShapeParametrization.cxx
+++ b/source/Core/TFCS2DFunctionLateralShapeParametrization.cxx
@@ -103,13 +103,13 @@ FCSReturnCode TFCS2DFunctionLateralShapeParametrization::simulate_hit(
     m_function->rnd_to_fct(alpha, r, rnd1, rnd2);
   }
   if (TMath::IsNaN(alpha) || TMath::IsNaN(r)) {
-    ATH_MSG_ERROR("  2D function, #hits=" << m_nhits << " alpha=" << alpha
+    FCS_MSG_ERROR("  2D function, #hits=" << m_nhits << " alpha=" << alpha
                                           << " r=" << r << " rnd1=" << rnd1
                                           << " rnd2=" << rnd2);
     alpha = 0;
     r = 0.001;
 
-    ATH_MSG_ERROR("  This error could probably be retried");
+    FCS_MSG_ERROR("  This error could probably be retried");
     return FCSFatal;
   }
 
@@ -136,7 +136,7 @@ FCSReturnCode TFCS2DFunctionLateralShapeParametrization::simulate_hit(
   hit.setEtaPhiZE(
       center_eta + delta_eta, center_phi + delta_phi, center_z, hit.E());
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
                           << " phi=" << hit.phi() << " z=" << hit.z()
                           << " r=" << r << " alpha=" << alpha);
 
@@ -162,17 +162,18 @@ void TFCS2DFunctionLateralShapeParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint) {
     if (is_phi_symmetric()) {
-      ATH_MSG_INFO(optprint << "  2D function, #hits=" << m_nhits
+      FCS_MSG_INFO(optprint << "  2D function, #hits=" << m_nhits
                             << " (phi symmetric)");
     } else {
-      ATH_MSG_INFO(optprint << "  2D function, #hits=" << m_nhits
+      FCS_MSG_INFO(optprint << "  2D function, #hits=" << m_nhits
                             << " (not phi symmetric)");
     }
   }

--- a/source/Core/TFCSCenterPositionCalculation.cxx
+++ b/source/Core/TFCSCenterPositionCalculation.cxx
@@ -37,10 +37,10 @@ FCSReturnCode TFCSCenterPositionCalculation::simulate_hit(
   if (!std::isfinite(r) || !std::isfinite(z) || !std::isfinite(eta)
       || !std::isfinite(phi))
   {
-    ATH_MSG_WARNING(
+    FCS_MSG_WARNING(
         "Extrapolator contains NaN or infinite number.\nSetting "
         "center position to calo boundary.");
-    ATH_MSG_WARNING("Before fix: center_r: "
+    FCS_MSG_WARNING("Before fix: center_r: "
                     << r << " center_z: " << z << " center_phi: " << phi
                     << " center_eta: " << eta << " weight: " << m_extrapWeight
                     << " cs: " << cs);
@@ -50,7 +50,7 @@ FCSReturnCode TFCSCenterPositionCalculation::simulate_hit(
     eta = extrapol->IDCaloBoundary_eta();
     phi = extrapol->IDCaloBoundary_phi();
 
-    ATH_MSG_WARNING("After fix: center_r: "
+    FCS_MSG_WARNING("After fix: center_r: "
                     << r << " center_z: " << z << " center_phi: " << phi
                     << " center_eta: " << eta << " weight: " << m_extrapWeight
                     << " cs: " << cs);
@@ -61,7 +61,7 @@ FCSReturnCode TFCSCenterPositionCalculation::simulate_hit(
   hit.setCenter_eta(eta);
   hit.setCenter_phi(phi);
 
-  ATH_MSG_DEBUG("TFCSCenterPositionCalculation: center_r: "
+  FCS_MSG_DEBUG("TFCSCenterPositionCalculation: center_r: "
                 << hit.center_r() << " center_z: " << hit.center_z()
                 << " center_phi: " << hit.center_phi()
                 << " center_eta: " << hit.center_eta()
@@ -74,12 +74,13 @@ void TFCSCenterPositionCalculation::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  Weight for extrapolated position: "
+    FCS_MSG_INFO(optprint << "  Weight for extrapolated position: "
                           << m_extrapWeight);
 }

--- a/source/Core/TFCSEnergyBinParametrization.cxx
+++ b/source/Core/TFCSEnergyBinParametrization.cxx
@@ -30,7 +30,7 @@ bool TFCSEnergyBinParametrization::is_match_Ekin_bin(int Ekin_bin) const
 void TFCSEnergyBinParametrization::resize()
 {
   for (int id : pdgid()) {
-    ATH_MSG_VERBOSE("PDGid=" << id << " resize to " << n_bins() + 1);
+    FCS_MSG_VERBOSE("PDGid=" << id << " resize to " << n_bins() + 1);
     m_pdgid_Ebin_probability[id].resize(n_bins() + 1);
   }
   for (auto it = m_pdgid_Ebin_probability.begin();
@@ -73,7 +73,7 @@ void TFCSEnergyBinParametrization::set_pdgid_Ekin_bin_probability(
 {
   add_pdgid(id);
   if (prob.size() != m_pdgid_Ebin_probability[id].size()) {
-    ATH_MSG_ERROR(
+    FCS_MSG_ERROR(
         "TFCSEnergyBinParametrization::set_pdgid_Ekin_bin_"
         "probability(): size of vectors does not match! in.size()="
         << prob.size() << " instance=" << m_pdgid_Ebin_probability[id].size());
@@ -101,7 +101,7 @@ bool TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_probability_from_file(
   std::vector<float> prob;
   prob.reserve(m_pdgid_Ebin_probability[id].size());
   if (probFromFile == nullptr) {
-    ATH_MSG_INFO(
+    FCS_MSG_INFO(
         "TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_"
         "probability_from_file(): "
         << prob_object_name << " is null. Using equal PCA probabilities.");
@@ -112,7 +112,7 @@ bool TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_probability_from_file(
   } else {
     auto size = static_cast<size_t>(probFromFile->GetNoElements());
     if (size != m_pdgid_Ebin_probability[id].size()) {
-      ATH_MSG_ERROR(
+      FCS_MSG_ERROR(
           "TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_probability_from_"
           "file(): size of prob array does not match! in.size()="
           << size << " instance=" << m_pdgid_Ebin_probability[id].size());
@@ -141,7 +141,8 @@ void TFCSEnergyBinParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSEnergyParametrization::Print(option);
@@ -149,18 +150,18 @@ void TFCSEnergyBinParametrization::Print(Option_t* option) const
     for (std::set<int>::iterator it = pdgid().begin(); it != pdgid().end();
          ++it)
     {
-      ATH_MSG(INFO) << optprint << "  PDGID=" << *it << " : ";
+      FCS_MSG(INFO) << optprint << "  PDGID=" << *it << " : ";
       float p = 0;
       for (int iEbin = 0; iEbin <= n_bins(); ++iEbin) {
         if (iEbin > 0)
-          ATH_MSG(INFO) << ", ";
+          FCS_MSG(INFO) << ", ";
         auto mapit = m_pdgid_Ebin_probability.find(*it);
-        ATH_MSG(INFO) << "b" << iEbin << "="
+        FCS_MSG(INFO) << "b" << iEbin << "="
                       << (mapit->second[iEbin] - p) / mapit->second.back() * 100
                       << "%";
         p = mapit->second[iEbin];
       }
-      ATH_MSG(INFO) << END_MSG(INFO);
+      FCS_MSG(INFO) << END_FCS_MSG(INFO);
     }
   }
 }
@@ -182,7 +183,7 @@ FCSReturnCode TFCSEnergyBinParametrization::simulate(
   else if (is_match_pdgid(0))
     pdgid = 0;
   else {
-    ATH_MSG_ERROR(
+    FCS_MSG_ERROR(
         "TFCSEnergyBinParametrization::simulate(): cannot simulate pdgid="
         << truth_pdgid);
     return FCSFatal;
@@ -194,7 +195,7 @@ FCSReturnCode TFCSEnergyBinParametrization::simulate(
       TMath::BinarySearch(n_bins() + 1, Ebin_probability.data(), searchRand)
       + 1;
   if (chosenBin < 0) {
-    ATH_MSG_WARNING(
+    FCS_MSG_WARNING(
         "TFCSEnergyBinParametrization::simulate(): chosenBin<0 "
         "(will use chosenBin=0)");
     std::string array = "";
@@ -202,11 +203,11 @@ FCSReturnCode TFCSEnergyBinParametrization::simulate(
       array += prob;
       array += " ";
     }
-    ATH_MSG_WARNING(" E=" << simulstate.E() << " Ebin=" << chosenBin
+    FCS_MSG_WARNING(" E=" << simulstate.E() << " Ebin=" << chosenBin
                           << " rnd=" << searchRand << " array=" << array);
     chosenBin = 0;
   } else if (chosenBin > n_bins()) {
-    ATH_MSG_WARNING(
+    FCS_MSG_WARNING(
         "TFCSEnergyBinParametrization::simulate(): "
         "chosenBin>n_bins() (will use chosenBin=n_bins())");
     std::string array = "";
@@ -214,12 +215,12 @@ FCSReturnCode TFCSEnergyBinParametrization::simulate(
       array += prob;
       array += " ";
     }
-    ATH_MSG_WARNING(" E=" << simulstate.E() << " Ebin=" << chosenBin
+    FCS_MSG_WARNING(" E=" << simulstate.E() << " Ebin=" << chosenBin
                           << " rnd=" << searchRand << " array=" << array);
     chosenBin = n_bins();
   }
   simulstate.set_Ebin(chosenBin);
-  ATH_MSG_DEBUG("Ebin=" << chosenBin);
+  FCS_MSG_DEBUG("Ebin=" << chosenBin);
 
   return FCSSuccess;
 }

--- a/source/Core/TFCSEnergyInterpolationHistogram.cxx
+++ b/source/Core/TFCSEnergyInterpolationHistogram.cxx
@@ -53,10 +53,10 @@ FCSReturnCode TFCSEnergyInterpolationHistogram::simulate(
   }
 
   if (OnlyScaleEnergy()) {
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin()
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin()
                            << " and E=" << Einit);
   } else {
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
   }
   simulstate.set_E(Emean);
 
@@ -67,13 +67,14 @@ void TFCSEnergyInterpolationHistogram::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSParametrization::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(
+    FCS_MSG_INFO(
         optprint << (OnlyScaleEnergy() ? "  E()*" : "  Ekin()*")
                  << "histNbins=" << m_hist.GetNbinsX() << " "
                  << m_hist.GetXaxis()->GetBinLowEdge(1) << "<=Ekin<="

--- a/source/Core/TFCSEnergyInterpolationLinear.cxx
+++ b/source/Core/TFCSEnergyInterpolationLinear.cxx
@@ -27,7 +27,7 @@ FCSReturnCode TFCSEnergyInterpolationLinear::simulate(
 {
   const float Emean = m_slope * truth->Ekin() + m_offset;
 
-  ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
+  FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
   simulstate.set_E(Emean);
 
   return FCSSuccess;
@@ -37,12 +37,13 @@ void TFCSEnergyInterpolationLinear::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSParametrization::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  Emean=" << m_slope << "*Ekin(true) + "
+    FCS_MSG_INFO(optprint << "  Emean=" << m_slope << "*Ekin(true) + "
                           << m_offset);
 }

--- a/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
+++ b/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
@@ -76,10 +76,10 @@ FCSReturnCode TFCSEnergyInterpolationPiecewiseLinear::simulate(
   }
 
   if (OnlyScaleEnergy())
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << Ekin
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << Ekin
                            << " and E=" << Einit);
   else
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << Ekin);
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << Ekin);
 
   // set mean energy of simulstate
   simulstate.set_E(Emean);
@@ -114,13 +114,14 @@ void TFCSEnergyInterpolationPiecewiseLinear::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSParametrization::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << (OnlyScaleEnergy() ? "  E()*" : "  Ekin()*")
+    FCS_MSG_INFO(optprint << (OnlyScaleEnergy() ? "  E()*" : "  Ekin()*")
                           << "linInterpol N=" << m_logEkin.size() << " "
                           << m_MinMaxlogEkin.first
                           << "<=log(Ekin)<=" << m_MinMaxlogEkin.second << " "

--- a/source/Core/TFCSEnergyInterpolationSpline.cxx
+++ b/source/Core/TFCSEnergyInterpolationSpline.cxx
@@ -84,10 +84,10 @@ FCSReturnCode TFCSEnergyInterpolationSpline::simulate(
   }
 
   if (OnlyScaleEnergy()) {
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin()
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin()
                            << " and E=" << Einit);
   } else {
-    ATH_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
+    FCS_MSG_DEBUG("set E=" << Emean << " for true Ekin=" << truth->Ekin());
   }
   simulstate.set_E(Emean);
 
@@ -98,13 +98,14 @@ void TFCSEnergyInterpolationSpline::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSParametrization::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << (OnlyScaleEnergy() ? "  E()*" : "  Ekin()*")
+    FCS_MSG_INFO(optprint << (OnlyScaleEnergy() ? "  E()*" : "  Ekin()*")
                           << "Spline N=" << m_spline.GetNp() << " "
                           << m_spline.GetXmin()
                           << "<=log(Ekin)<=" << m_spline.GetXmax() << " "

--- a/source/Core/TFCSEnergyRenormalization.cxx
+++ b/source/Core/TFCSEnergyRenormalization.cxx
@@ -56,14 +56,14 @@ FCSReturnCode TFCSEnergyRenormalization::simulate(
     if (energies[layer] == 0 && simulstate.E(layer) != 0) {
       if (simulstate.E(layer) > 8.0 * approxLayerNoise.at(layer) && layer != 5
           && layer != 6 && layer != 7)
-        ATH_MSG_INFO(
+        FCS_MSG_INFO(
             "TFCSEnergyRenormalization::simulate(): energy not simulated "
             "(out-of-calo) in layer "
             << layer << " expected: " << simulstate.E(layer)
             << " simulated: " << energies[layer]);
       if (simulstate.E(layer) > 1500.0
           && (layer == 5 || layer == 6 || layer == 7))
-        ATH_MSG_INFO(
+        FCS_MSG_INFO(
             "TFCSEnergyRenormalization::simulate(): energy not simulated "
             "(out-of-calo) in layer "
             << layer << " expected: " << simulstate.E(layer)
@@ -82,10 +82,10 @@ FCSReturnCode TFCSEnergyRenormalization::simulate(
     cell_iter.second *= scalefactor[layer];
   }
 
-  if (msgLvl(MSG::DEBUG)) {
-    ATH_MSG_DEBUG("Apply scale factors : ");
+  if (msgLvl(FCS_MSG::DEBUG)) {
+    FCS_MSG_DEBUG("Apply scale factors : ");
     for (int layer = 0; layer < m_geo->n_layers(); ++layer) {
-      ATH_MSG_DEBUG("  " << layer << " *= " << scalefactor[layer] << " : "
+      FCS_MSG_DEBUG("  " << layer << " *= " << scalefactor[layer] << " : "
                          << energies[layer] << " -> " << simulstate.E(layer));
     }
   }

--- a/source/Core/TFCSExtrapolationState.cxx
+++ b/source/Core/TFCSExtrapolationState.cxx
@@ -16,7 +16,7 @@ TFCSExtrapolationState::TFCSExtrapolationState()
 void TFCSExtrapolationState::Print(Option_t*) const
 {
   // Print the IDCaloBoundary information
-  ATH_MSG_INFO("IDCalo: eta="
+  FCS_MSG_INFO("IDCalo: eta="
                << m_IDCaloBoundary_eta << " phi=" << m_IDCaloBoundary_phi
                << " r=" << m_IDCaloBoundary_r << " z=" << m_IDCaloBoundary_z);
 
@@ -25,7 +25,7 @@ void TFCSExtrapolationState::Print(Option_t*) const
     int layer = key.first;
     int subpos = key.second;
     if (ok) {
-      ATH_MSG_INFO("  layer " << layer << " subpos " << subpos
+      FCS_MSG_INFO("  layer " << layer << " subpos " << subpos
                               << " MID eta=" << m_etaCalo.at({layer, subpos})
                               << " phi=" << m_phiCalo.at({layer, subpos})
                               << " r=" << m_rCalo.at({layer, subpos})

--- a/source/Core/TFCSFlatLateralShapeParametrization.cxx
+++ b/source/Core/TFCSFlatLateralShapeParametrization.cxx
@@ -86,7 +86,7 @@ FCSReturnCode TFCSFlatLateralShapeParametrization::simulate_hit(
                   center_z,
                   hit.E() * m_scale);
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
                           << " phi=" << hit.phi() << " z=" << hit.z()
                           << " r=" << r << " alpha=" << alpha);
 
@@ -97,13 +97,14 @@ void TFCSFlatLateralShapeParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint) {
-    ATH_MSG_INFO(optprint << "  dR=" << m_dR << " scale factor=" << m_scale
+    FCS_MSG_INFO(optprint << "  dR=" << m_dR << " scale factor=" << m_scale
                           << ", #hits=" << m_nhits);
   }
 }

--- a/source/Core/TFCSGANEtaSlice.cxx
+++ b/source/Core/TFCSGANEtaSlice.cxx
@@ -89,7 +89,7 @@ bool TFCSGANEtaSlice::LoadGAN()
     inputFileName = m_param.GetInputFolder() + "/neural_net_"
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_All.*";
-    ATH_MSG_DEBUG("Gan input file name " << inputFileName);
+    FCS_MSG_DEBUG("Gan input file name " << inputFileName);
     m_net_all = TFCSNetworkFactory::create(inputFileName);
     if (m_net_all == nullptr)
       success = false;
@@ -97,7 +97,7 @@ bool TFCSGANEtaSlice::LoadGAN()
     inputFileName = m_param.GetInputFolder() + "/neural_net_"
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_High10.*";
-    ATH_MSG_DEBUG("Gan input file name " << inputFileName);
+    FCS_MSG_DEBUG("Gan input file name " << inputFileName);
     m_net_all = TFCSNetworkFactory::create(inputFileName);
     if (m_net_all == nullptr)
       success = false;
@@ -105,7 +105,7 @@ bool TFCSGANEtaSlice::LoadGAN()
     inputFileName = m_param.GetInputFolder() + "/neural_net_"
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_High12.*";
-    ATH_MSG_DEBUG("Gan input file name " << inputFileName);
+    FCS_MSG_DEBUG("Gan input file name " << inputFileName);
     m_net_high = TFCSNetworkFactory::create(inputFileName);
     if (m_net_high == nullptr)
       success = false;
@@ -125,10 +125,10 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
   std::string rootFileName = m_param.GetInputFolder() + "/rootFiles/pid"
       + std::to_string(m_pid) + "_E1048576_eta_" + std::to_string(m_etaMin)
       + "_" + std::to_string(m_etaMin + 5) + ".root";
-  ATH_MSG_DEBUG("Opening file " << rootFileName);
+  FCS_MSG_DEBUG("Opening file " << rootFileName);
   TFile* file = TFile::Open(rootFileName.c_str(), "read");
   for (int layer : m_param.GetRelevantLayers()) {
-    ATH_MSG_DEBUG("Layer " << layer);
+    FCS_MSG_DEBUG("Layer " << layer);
     TFCSGANXMLParameters::Binning binsInLayers = m_param.GetBinning();
     TH2D* h2 = &binsInLayers[layer];
 
@@ -141,7 +141,7 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
 
     TAxis* x = (TAxis*)h2->GetXaxis();
     for (int ix = 1; ix <= h2->GetNbinsX(); ++ix) {
-      ATH_MSG_DEBUG(ix);
+      FCS_MSG_DEBUG(ix);
       h1->GetXaxis()->SetRangeUser(x->GetBinLowEdge(ix), x->GetBinUpEdge(ix));
 
       double result = 0;
@@ -156,7 +156,7 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
       m_allFitResults[layer].push_back(result);
     }
   }
-  ATH_MSG_DEBUG("Done initializing fits");
+  FCS_MSG_DEBUG("Done initializing fits");
 }
 
 void TFCSGANEtaSlice::ExtractExtrapolatorMeansFromInputs()
@@ -164,7 +164,7 @@ void TFCSGANEtaSlice::ExtractExtrapolatorMeansFromInputs()
   std::string rootFileName = m_param.GetInputFolder() + "/rootFiles/pid"
       + std::to_string(m_pid) + "_E65536_eta_" + std::to_string(m_etaMin) + "_"
       + std::to_string(m_etaMin + 5) + "_validation.root";
-  ATH_MSG_DEBUG("Opening file " << rootFileName);
+  FCS_MSG_DEBUG("Opening file " << rootFileName);
   TFile* file = TFile::Open(rootFileName.c_str(), "read");
   for (int layer : m_param.GetRelevantLayers()) {
     std::string branchName = "extrapWeight_" + std::to_string(layer);
@@ -173,7 +173,7 @@ void TFCSGANEtaSlice::ExtractExtrapolatorMeansFromInputs()
     std::string command = branchName + ">>h";
     tree->Draw(command.c_str());
     m_extrapolatorWeights[layer] = h->GetMean();
-    ATH_MSG_DEBUG("Extrapolation: layer " << layer << " mean "
+    FCS_MSG_DEBUG("Extrapolation: layer " << layer << " mean "
                                           << m_extrapolatorWeights[layer]);
   }
 }
@@ -221,7 +221,7 @@ VNetworkBase::NetworkOutputs TFCSGANEtaSlice::GetNetworkOutputs(
 
   // double e = log(truth->Ekin()/Ekin_min)/log(Ekin_max/Ekin_min) ;
   // Could be uncommented , but would need the line above too
-  // ATH_MSG_DEBUG( "Check label: " << e <<" Ekin:" << truth->Ekin() <<" p:" <<
+  // FCS_MSG_DEBUG( "Check label: " << e <<" Ekin:" << truth->Ekin() <<" p:" <<
   //                truth->P() <<" mass:" << truth->M() <<" Ekin_off:" <<
   //                truth->Ekin_off() << " Ekin_min:"<<Ekin_min<<"
   //                Ekin_max:"<<Ekin_max);
@@ -249,26 +249,26 @@ VNetworkBase::NetworkOutputs TFCSGANEtaSlice::GetNetworkOutputs(
     if (truth->P() > 4096)
     {  // This is the momentum, not the energy, because the split is
        // based on the samples which are produced with the momentum
-      ATH_MSG_DEBUG("Computing outputs given inputs for high");
+      FCS_MSG_DEBUG("Computing outputs given inputs for high");
       outputs = GetNetHigh()->compute(inputs);
     } else {
       outputs = GetNetLow()->compute(inputs);
     }
   }
-  ATH_MSG_DEBUG("Start Network inputs ~~~~~~~~");
-  ATH_MSG_DEBUG(VNetworkBase::representNetworkInputs(inputs, 10000));
-  ATH_MSG_DEBUG("End Network inputs ~~~~~~~~");
-  ATH_MSG_DEBUG("Start Network outputs ~~~~~~~~");
-  ATH_MSG_DEBUG(VNetworkBase::representNetworkOutputs(outputs, 10000));
-  ATH_MSG_DEBUG("End Network outputs ~~~~~~~~");
+  FCS_MSG_DEBUG("Start Network inputs ~~~~~~~~");
+  FCS_MSG_DEBUG(VNetworkBase::representNetworkInputs(inputs, 10000));
+  FCS_MSG_DEBUG("End Network inputs ~~~~~~~~");
+  FCS_MSG_DEBUG("Start Network outputs ~~~~~~~~");
+  FCS_MSG_DEBUG(VNetworkBase::representNetworkOutputs(outputs, 10000));
+  FCS_MSG_DEBUG("End Network outputs ~~~~~~~~");
   return outputs;
 }
 
 void TFCSGANEtaSlice::Print() const
 {
-  ATH_MSG_INFO("LWTNN Handler parameters");
-  ATH_MSG_INFO("  pid: " << m_pid);
-  ATH_MSG_INFO("  etaMin:" << m_etaMin);
-  ATH_MSG_INFO("  etaMax: " << m_etaMax);
+  FCS_MSG_INFO("LWTNN Handler parameters");
+  FCS_MSG_INFO("  pid: " << m_pid);
+  FCS_MSG_INFO("  etaMin:" << m_etaMin);
+  FCS_MSG_INFO("  etaMax: " << m_etaMax);
   m_param.Print();
 }

--- a/source/Core/TFCSGANLWTNNHandler.cxx
+++ b/source/Core/TFCSGANLWTNNHandler.cxx
@@ -13,7 +13,7 @@
 TFCSGANLWTNNHandler::TFCSGANLWTNNHandler(const std::string& inputFile)
     : VNetworkLWTNN(inputFile)
 {
-  ATH_MSG_DEBUG("Setting up from inputFile.");
+  FCS_MSG_DEBUG("Setting up from inputFile.");
   setupPersistedVariables();
   TFCSGANLWTNNHandler::setupNet();
 };
@@ -23,7 +23,7 @@ TFCSGANLWTNNHandler::TFCSGANLWTNNHandler(const TFCSGANLWTNNHandler& copy_from)
 {
   // Cannot take copies of lwt::LightweightGraph
   // (copy constructor disabled)
-  ATH_MSG_DEBUG("Making a new m_lwtnn_graph for copied network");
+  FCS_MSG_DEBUG("Making a new m_lwtnn_graph for copied network");
   std::stringstream json_stream(m_json);
   const lwt::GraphConfig config = lwt::parse_json_graph(json_stream);
   m_lwtnn_graph = std::make_unique<lwt::LightweightGraph>(config);
@@ -39,26 +39,26 @@ void TFCSGANLWTNNHandler::setupNet()
     m_input = nullptr;
   }
   // build the graph
-  ATH_MSG_VERBOSE("m_json has size " << m_json.length());
-  ATH_MSG_DEBUG("m_json starts with  " << m_json.substr(0, 10));
-  ATH_MSG_VERBOSE("Reading the m_json string stream into a graph network");
+  FCS_MSG_VERBOSE("m_json has size " << m_json.length());
+  FCS_MSG_DEBUG("m_json starts with  " << m_json.substr(0, 10));
+  FCS_MSG_VERBOSE("Reading the m_json string stream into a graph network");
   std::stringstream json_stream(m_json);
   const lwt::GraphConfig config = lwt::parse_json_graph(json_stream);
   m_lwtnn_graph = std::make_unique<lwt::LightweightGraph>(config);
   // Get the output layers
-  ATH_MSG_VERBOSE("Getting output layers for neural network");
+  FCS_MSG_VERBOSE("Getting output layers for neural network");
   for (auto node : config.outputs) {
     const std::string node_name = node.first;
     const lwt::OutputNodeConfig node_config = node.second;
     for (const std::string& label : node_config.labels) {
-      ATH_MSG_VERBOSE("Found output layer called " << node_name << "_"
+      FCS_MSG_VERBOSE("Found output layer called " << node_name << "_"
                                                    << label);
       m_outputLayers.push_back(node_name + "_" + label);
     }
   };
-  ATH_MSG_VERBOSE("Removing prefix from stored layers.");
+  FCS_MSG_VERBOSE("Removing prefix from stored layers.");
   removePrefixes(m_outputLayers);
-  ATH_MSG_VERBOSE("Finished output nodes.");
+  FCS_MSG_VERBOSE("Finished output nodes.");
 };
 
 std::vector<std::string> TFCSGANLWTNNHandler::getOutputLayers() const
@@ -71,7 +71,7 @@ std::vector<std::string> TFCSGANLWTNNHandler::getOutputLayers() const
 TFCSGANLWTNNHandler::NetworkOutputs TFCSGANLWTNNHandler::compute(
     TFCSGANLWTNNHandler::NetworkInputs const& inputs) const
 {
-  ATH_MSG_DEBUG("Running computation on LWTNN graph network");
+  FCS_MSG_DEBUG("Running computation on LWTNN graph network");
   NetworkInputs local_copy = inputs;
   if (inputs.find("Noise") != inputs.end()) {
     // Graphs from EnergyAndHitsGANV2 have the local_copy encoded as Noise =
@@ -87,20 +87,20 @@ TFCSGANLWTNNHandler::NetworkOutputs TFCSGANLWTNNHandler::compute(
   TFCSGANLWTNNHandler::NetworkOutputs outputs =
       m_lwtnn_graph->compute(local_copy);
   removePrefixes(outputs);
-  ATH_MSG_DEBUG("Computation on LWTNN graph network done, returning.");
+  FCS_MSG_DEBUG("Computation on LWTNN graph network done, returning.");
   return outputs;
 };
 
 // Giving this it's own streamer to call setupNet
 void TFCSGANLWTNNHandler::Streamer(TBuffer& buf)
 {
-  ATH_MSG_DEBUG("In streamer of " << __FILE__);
+  FCS_MSG_DEBUG("In streamer of " << __FILE__);
   if (buf.IsReading()) {
-    ATH_MSG_DEBUG("Reading buffer in TFCSGANLWTNNHandler ");
+    FCS_MSG_DEBUG("Reading buffer in TFCSGANLWTNNHandler ");
     // Get the persisted variables filled in
     TFCSGANLWTNNHandler::Class()->ReadBuffer(buf, this);
-    ATH_MSG_DEBUG("m_json has size " << m_json.length());
-    ATH_MSG_DEBUG("m_json starts with  " << m_json.substr(0, 10));
+    FCS_MSG_DEBUG("m_json has size " << m_json.length());
+    FCS_MSG_DEBUG("m_json starts with  " << m_json.substr(0, 10));
     // Setup the net, creating the non persisted variables
     // exactly as in the constructor
     this->setupNet();
@@ -111,9 +111,9 @@ void TFCSGANLWTNNHandler::Streamer(TBuffer& buf)
 #endif
   } else {
     if (!m_json.empty()) {
-      ATH_MSG_DEBUG("Writing buffer in TFCSGANLWTNNHandler ");
+      FCS_MSG_DEBUG("Writing buffer in TFCSGANLWTNNHandler ");
     } else {
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "Writing buffer in TFCSGANLWTNNHandler, but m_json is empty");
     };
     // Persist variables

--- a/source/Core/TFCSGANXMLParameters.cxx
+++ b/source/Core/TFCSGANXMLParameters.cxx
@@ -117,15 +117,15 @@ bool TFCSGANXMLParameters::ReadBooleanAttribute(const std::string& name,
 
 void TFCSGANXMLParameters::Print() const
 {
-  ATH_MSG_INFO("Parameters taken from XML");
-  ATH_MSG_INFO("  symmetrisedAlpha: " << m_symmetrisedAlpha);
-  ATH_MSG_INFO("  ganVersion:" << m_ganVersion);
-  ATH_MSG_INFO("  latentDim: " << m_latentDim);
-  ATH_MSG(INFO) << "  relevantlayers: ";
+  FCS_MSG_INFO("Parameters taken from XML");
+  FCS_MSG_INFO("  symmetrisedAlpha: " << m_symmetrisedAlpha);
+  FCS_MSG_INFO("  ganVersion:" << m_ganVersion);
+  FCS_MSG_INFO("  latentDim: " << m_latentDim);
+  FCS_MSG(INFO) << "  relevantlayers: ";
   for (auto l : m_relevantlayers) {
-    ATH_MSG(INFO) << l << " ";
+    FCS_MSG(INFO) << l << " ";
   }
-  ATH_MSG(INFO) << END_MSG(INFO);
+  FCS_MSG(INFO) << END_FCS_MSG(INFO);
 
   for (auto element : m_binning) {
     int layer = element.first;
@@ -136,15 +136,15 @@ void TFCSGANXMLParameters::Print() const
 
     // If only one bin in r means layer is empty, no value should be added
     if (xBinNum == 1) {
-      ATH_MSG_INFO("layer " << layer << " not used");
+      FCS_MSG_INFO("layer " << layer << " not used");
       continue;
     }
-    ATH_MSG_INFO("Binning along r for layer " << layer);
-    ATH_MSG(INFO) << "0,";
+    FCS_MSG_INFO("Binning along r for layer " << layer);
+    FCS_MSG(INFO) << "0,";
     // First fill energies
     for (int ix = 1; ix <= xBinNum; ++ix) {
-      ATH_MSG(INFO) << x->GetBinUpEdge(ix) << ",";
+      FCS_MSG(INFO) << x->GetBinUpEdge(ix) << ",";
     }
-    ATH_MSG(INFO) << END_MSG(INFO);
+    FCS_MSG(INFO) << END_FCS_MSG(INFO);
   }
 }

--- a/source/Core/TFCSHistoLateralShapeGausLogWeight.cxx
+++ b/source/Core/TFCSHistoLateralShapeGausLogWeight.cxx
@@ -63,7 +63,7 @@ FCSReturnCode TFCSHistoLateralShapeGausLogWeight::simulate_hit(
   }
   hit.set_E(weight * hit.E());
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
                           << " weight=" << weight);
   return FCSSuccess;
 }

--- a/source/Core/TFCSHistoLateralShapeGausLogWeightHitAndMiss.cxx
+++ b/source/Core/TFCSHistoLateralShapeGausLogWeightHitAndMiss.cxx
@@ -83,7 +83,7 @@ FCSReturnCode TFCSHistoLateralShapeGausLogWeightHitAndMiss::simulate_hit(
       hit.set_E(0);
   }
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
                           << " meanweight=" << meanweight
                           << " weight=" << weight);
   return FCSSuccess;

--- a/source/Core/TFCSHistoLateralShapeParametrization.cxx
+++ b/source/Core/TFCSHistoLateralShapeParametrization.cxx
@@ -36,7 +36,7 @@ void TFCSHistoLateralShapeParametrization::set_geometry(CaloGeo* geo)
     int first_fix_bin = -1;
     for (int i = (int)(m_hist.get_HistoContents().size() - 1); i >= 0; --i) {
       if (std::isnan(m_hist.get_HistoContents()[i])) {
-        ATH_MSG_DEBUG("nan in histo content for "
+        FCS_MSG_DEBUG("nan in histo content for "
                       << GetTitle() << ", bin[" << i
                       << "]=" << m_hist.get_HistoContents()[i] << " -> 1");
         m_hist.get_HistoContents()[i] = 1;
@@ -47,7 +47,7 @@ void TFCSHistoLateralShapeParametrization::set_geometry(CaloGeo* geo)
       return;
 
     if (first_fix_bin == 0) {
-      ATH_MSG_WARNING("nan in histo content for "
+      FCS_MSG_WARNING("nan in histo content for "
                       << GetTitle()
                       << " for all bins. Fixed to probability 1 causing hits "
                          "to be deposited in the shower center");
@@ -55,14 +55,14 @@ void TFCSHistoLateralShapeParametrization::set_geometry(CaloGeo* geo)
       int last_fix_bin = -1;
       for (size_t i = 0; i < m_hist.get_HistoContents().size(); ++i) {
         if (std::isnan(m_hist.get_HistoContents()[i])) {
-          ATH_MSG_DEBUG("nan in histo content for "
+          FCS_MSG_DEBUG("nan in histo content for "
                         << GetTitle() << ", bin[" << i
                         << "]=" << m_hist.get_HistoContents()[i] << " -> 0");
           m_hist.get_HistoContents()[i] = 0;
           last_fix_bin = i;
         }
       }
-      ATH_MSG_WARNING("nan in histo content for "
+      FCS_MSG_WARNING("nan in histo content for "
                       << GetTitle() << ". Fixed up to bin " << last_fix_bin
                       << " with probability 0 and beyond bin " << first_fix_bin
                       << " with probability 1.");
@@ -140,7 +140,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrization::simulate_hit(
     m_hist.rnd_to_fct(alpha, r, rnd1, rnd2);
   }
   if (TMath::IsNaN(alpha) || TMath::IsNaN(r)) {
-    ATH_MSG_ERROR("  Histogram: "
+    FCS_MSG_ERROR("  Histogram: "
                   << m_hist.get_HistoBordersx().size() - 1 << "*"
                   << m_hist.get_HistoBordersy().size() - 1
                   << " bins, #hits=" << m_nhits << " alpha=" << alpha
@@ -148,7 +148,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrization::simulate_hit(
     alpha = 0;
     r = 0.001;
 
-    ATH_MSG_ERROR("  This error could probably be retried");
+    FCS_MSG_ERROR("  This error could probably be retried");
     return FCSFatal;
   }
 
@@ -180,7 +180,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrization::simulate_hit(
   hit.setEtaPhiZE(
       center_eta + delta_eta, center_phi + delta_phi, center_z, hit.E());
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
                           << " phi=" << hit.phi() << " z=" << hit.z()
                           << " r=" << r << " alpha=" << alpha);
 
@@ -224,20 +224,21 @@ void TFCSHistoLateralShapeParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint) {
     if (is_phi_symmetric()) {
-      ATH_MSG_INFO(optprint
+      FCS_MSG_INFO(optprint
                    << "  Histo: " << m_hist.get_HistoBordersx().size() - 1
                    << "*" << m_hist.get_HistoBordersy().size() - 1
                    << " bins, #hits=" << m_nhits << ", r scale=" << m_r_scale
                    << ", r offset=" << m_r_offset << "mm (phi symmetric)");
     } else {
-      ATH_MSG_INFO(optprint
+      FCS_MSG_INFO(optprint
                    << "  Histo: " << m_hist.get_HistoBordersx().size() - 1
                    << "*" << m_hist.get_HistoBordersy().size() - 1
                    << " bins, #hits=" << m_nhits << ", r scale=" << m_r_scale

--- a/source/Core/TFCSHistoLateralShapeParametrizationFCal.cxx
+++ b/source/Core/TFCSHistoLateralShapeParametrizationFCal.cxx
@@ -65,7 +65,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrizationFCal::simulate_hit(
     m_hist.rnd_to_fct(alpha, r, rnd1, rnd2);
   }
   if (TMath::IsNaN(alpha) || TMath::IsNaN(r)) {
-    ATH_MSG_ERROR("  Histogram: "
+    FCS_MSG_ERROR("  Histogram: "
                   << m_hist.get_HistoBordersx().size() - 1 << "*"
                   << m_hist.get_HistoBordersy().size() - 1
                   << " bins, #hits=" << m_nhits << " alpha=" << alpha
@@ -73,7 +73,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrizationFCal::simulate_hit(
     alpha = 0;
     r = 0.001;
 
-    ATH_MSG_ERROR("  This error could probably be retried");
+    FCS_MSG_ERROR("  This error could probably be retried");
     return FCSFatal;
   }
 
@@ -88,7 +88,7 @@ FCSReturnCode TFCSHistoLateralShapeParametrizationFCal::simulate_hit(
 
   hit.setXYZE(hit_r * cos(hit_phi), hit_r * sin(hit_phi), center_z, hit.E());
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " x=" << hit.x()
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " x=" << hit.x()
                           << " y=" << hit.y() << " z=" << hit.z() << " r=" << r
                           << " alpha=" << alpha);
 

--- a/source/Core/TFCSHistoLateralShapeWeight.cxx
+++ b/source/Core/TFCSHistoLateralShapeWeight.cxx
@@ -78,7 +78,7 @@ FCSReturnCode TFCSHistoLateralShapeWeight::simulate_hit(
   }
   hit.set_E(weight * hit.E());
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
                           << " weight=" << weight);
   return FCSSuccess;
 }
@@ -100,20 +100,21 @@ void TFCSHistoLateralShapeWeight::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint) {
     if (m_hist)
-      ATH_MSG_INFO(optprint
+      FCS_MSG_INFO(optprint
                    << "  Histogram: " << m_hist->GetNbinsX() << " bins ["
                    << std::as_const(m_hist)->GetXaxis()->GetXmin() << ","
                    << std::as_const(m_hist)->GetXaxis()->GetXmax() << "]"
                    << " min weight: " << m_minWeight
                    << " max weight: " << m_maxWeight);
     else
-      ATH_MSG_INFO(optprint << "  no Histogram");
+      FCS_MSG_INFO(optprint << "  no Histogram");
   }
 }

--- a/source/Core/TFCSHistoLateralShapeWeightHitAndMiss.cxx
+++ b/source/Core/TFCSHistoLateralShapeWeightHitAndMiss.cxx
@@ -91,7 +91,7 @@ FCSReturnCode TFCSHistoLateralShapeWeightHitAndMiss::simulate_hit(
   }
 
   hit.set_E(weight * hit.E());
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " dR_mm=" << delta_r_mm
                           << " meanweight=" << meanweight
                           << " weight=" << weight);
 

--- a/source/Core/TFCSHitCellMapping.cxx
+++ b/source/Core/TFCSHitCellMapping.cxx
@@ -27,7 +27,7 @@ FCSReturnCode TFCSHitCellMapping::simulate_hit(
     const TFCSTruthState* /*truth*/,
     const TFCSExtrapolationState* /*extrapol*/)
 {
-  ATH_MSG_DEBUG("Got hit with E=" << hit.E() << " eta=" << hit.eta()
+  FCS_MSG_DEBUG("Got hit with E=" << hit.E() << " eta=" << hit.eta()
                                   << " phi=" << hit.phi());
 
   // Position where we will perform the lookup
@@ -35,14 +35,14 @@ FCSReturnCode TFCSHitCellMapping::simulate_hit(
 
   // Get the best matching cell
   const auto& cell = m_geo->get_cell(calosample(), lookup_pos);
-  ATH_MSG_DEBUG(cell);
+  FCS_MSG_DEBUG(cell);
 
   // Get hit-cell boundary proximity
   // < 0 means we are inside the cell
   // > 0 means we are outside the cell
   double proximity = cell.boundary_proximity(lookup_pos);
 
-  ATH_MSG_DEBUG("Hit-cell distance in eta-phi is: " << proximity);
+  FCS_MSG_DEBUG("Hit-cell distance in eta-phi is: " << proximity);
 
   // If the distance is positive then we are using the nearest cell rather
   // than are inside a cell If we are more than 0.005mm from the nearest cell
@@ -74,13 +74,14 @@ void TFCSHitCellMapping::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  geo=" << m_geo);
+    FCS_MSG_INFO(optprint << "  geo=" << m_geo);
 }
 
 #pragma GCC diagnostic push

--- a/source/Core/TFCSHitCellMappingFCal.cxx
+++ b/source/Core/TFCSHitCellMappingFCal.cxx
@@ -18,7 +18,7 @@ FCSReturnCode TFCSHitCellMappingFCal::simulate_hit(
     const TFCSTruthState* /*truth*/,
     const TFCSExtrapolationState* /*extrapol*/)
 {
-  ATH_MSG_DEBUG("Got hit with E=" << hit.E() << " x=" << hit.x()
+  FCS_MSG_DEBUG("Got hit with E=" << hit.E() << " x=" << hit.x()
                                   << " y=" << hit.y());
 
   // Position where we perform the lookup
@@ -32,11 +32,11 @@ FCSReturnCode TFCSHitCellMappingFCal::simulate_hit(
   }
   // Get the best matching cell
   const auto& cell = m_geo->get_cell(calosample(), lookup_pos);
-  ATH_MSG_DEBUG(cell);
+  FCS_MSG_DEBUG(cell);
 
   /// Could not find a cell, retry simulation up to 5 times
   if (!cell.is_valid()) {
-    ATH_MSG_WARNING("Hit in layer " << calosample() << " with E = " << hit.E()
+    FCS_MSG_WARNING("Hit in layer " << calosample() << " with E = " << hit.E()
                                     << " x = " << hit.x() << " y = " << hit.y()
                                     << " could not be matched to a cell");
     return (FCSReturnCode)(FCSRetry + 5);
@@ -47,7 +47,7 @@ FCSReturnCode TFCSHitCellMappingFCal::simulate_hit(
   // > 0 means we are outside the cell
   double proximity = cell.boundary_proximity(lookup_pos);
 
-  ATH_MSG_DEBUG("Hit-cell distance in x-y is: " << proximity);
+  FCS_MSG_DEBUG("Hit-cell distance in x-y is: " << proximity);
 
   // If the distance is positive then we are using the nearest cell rather than
   // are inside a cell If we are more than 2.25mm from the nearest cell we don't

--- a/source/Core/TFCSHitCellMappingWiggle.cxx
+++ b/source/Core/TFCSHitCellMappingWiggle.cxx
@@ -53,7 +53,7 @@ void TFCSHitCellMappingWiggle::initialize(
     const std::vector<float>& bin_low_edges)
 {
   if (functions.size() + 1 != bin_low_edges.size()) {
-    ATH_MSG_ERROR("Using " << functions.size() << " functions needs "
+    FCS_MSG_ERROR("Using " << functions.size() << " functions needs "
                            << functions.size() + 1 << " bin low edges, but got "
                            << bin_low_edges.size() << "bins");
     return;
@@ -84,7 +84,7 @@ void TFCSHitCellMappingWiggle::initialize(
     float xscale)
 {
   if (histograms.size() + 1 != bin_low_edges.size()) {
-    ATH_MSG_ERROR("Using " << histograms.size() << " histograms needs "
+    FCS_MSG_ERROR("Using " << histograms.size() << " histograms needs "
                            << histograms.size() + 1 << " bins, but got "
                            << bin_low_edges.size() << "bins");
     return;
@@ -131,7 +131,7 @@ FCSReturnCode TFCSHitCellMappingWiggle::simulate_hit(
 
     double wiggle = func->rnd_to_fct(rnd);
 
-    ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << calosample()
+    FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << calosample()
                             << " eta=" << hit.eta() << " phi=" << hit.phi()
                             << " wiggle=" << wiggle << " bin=" << bin << " ["
                             << get_bin_low_edge(bin) << ","
@@ -164,24 +164,26 @@ void TFCSHitCellMappingWiggle::Print(Option_t* option) const
   TFCSHitCellMapping::Print(option);
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
 
   if (longprint) {
-    ATH_MSG(INFO) << optprint << "  " << get_number_of_bins()
+    FCS_MSG(INFO) << optprint << "  " << get_number_of_bins()
                   << " functions : ";
     for (unsigned int i = 0; i < get_number_of_bins(); ++i)
-      ATH_MSG(INFO) << get_bin_low_edge(i) << " < (" << get_function(i)
+      FCS_MSG(INFO) << get_bin_low_edge(i) << " < (" << get_function(i)
                     << ") < ";
-    ATH_MSG(INFO) << get_bin_up_edge(get_number_of_bins() - 1) << END_MSG(INFO);
+    FCS_MSG(INFO) << get_bin_up_edge(get_number_of_bins() - 1)
+                  << END_FCS_MSG(INFO);
   }
 }
 
 bool TFCSHitCellMappingWiggle::compare(const TFCSParametrizationBase& ref) const
 {
   if (IsA() != ref.IsA()) {
-    ATH_MSG_DEBUG("compare(): different class types "
+    FCS_MSG_DEBUG("compare(): different class types "
                   << IsA()->GetName() << " != " << ref.IsA()->GetName());
     return false;
   }
@@ -189,7 +191,7 @@ bool TFCSHitCellMappingWiggle::compare(const TFCSParametrizationBase& ref) const
       static_cast<const TFCSHitCellMappingWiggle&>(ref);
 
   if (m_bin_low_edge != ref_typed.m_bin_low_edge) {
-    ATH_MSG_DEBUG("operator==(): different bin edges");
+    FCS_MSG_DEBUG("operator==(): different bin edges");
     return false;
   }
 
@@ -199,18 +201,18 @@ bool TFCSHitCellMappingWiggle::compare(const TFCSParametrizationBase& ref) const
     if (!f1 && !f2)
       continue;
     if ((f1 && !f2) || (!f1 && f2)) {
-      ATH_MSG_DEBUG(
+      FCS_MSG_DEBUG(
           "compare(): different only one function pointer is nullptr");
       return false;
     }
     if (f1->IsA() != f2->IsA()) {
-      ATH_MSG_DEBUG("compare(): different class types for function "
+      FCS_MSG_DEBUG("compare(): different class types for function "
                     << i << ": " << f1->IsA()->GetName()
                     << " != " << f2->IsA()->GetName());
       return false;
     }
     if (!(*f1 == *f2)) {
-      ATH_MSG_DEBUG("compare(): difference in functions " << i);
+      FCS_MSG_DEBUG("compare(): difference in functions " << i);
       return false;
     }
   }

--- a/source/Core/TFCSHitCellMappingWiggleEMB.cxx
+++ b/source/Core/TFCSHitCellMappingWiggleEMB.cxx
@@ -107,7 +107,7 @@ FCSReturnCode TFCSHitCellMappingWiggleEMB::simulate_hit(
   if (cs < 4 && cs > 0)
     wiggle = doWiggle(CLHEP::RandFlat::shoot(simulstate.randomEngine()));
 
-  ATH_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
+  FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " eta=" << hit.eta()
                           << " phi=" << hit.phi() << " wiggle=" << wiggle);
 
   double hit_phi_shifted = hit.phi() - wiggle;

--- a/source/Core/TFCSInitWithEkin.cxx
+++ b/source/Core/TFCSInitWithEkin.cxx
@@ -19,7 +19,7 @@ FCSReturnCode TFCSInitWithEkin::simulate(TFCSSimulationState& simulstate,
                                          const TFCSTruthState* truth,
                                          const TFCSExtrapolationState*) const
 {
-  ATH_MSG_DEBUG("set E to Ekin=" << truth->Ekin());
+  FCS_MSG_DEBUG("set E to Ekin=" << truth->Ekin());
   simulstate.set_E(truth->Ekin());
   return FCSSuccess;
 }

--- a/source/Core/TFCSInvisibleParametrization.cxx
+++ b/source/Core/TFCSInvisibleParametrization.cxx
@@ -11,7 +11,7 @@ FCSReturnCode TFCSInvisibleParametrization::simulate(
     const TFCSTruthState* /*truth*/,
     const TFCSExtrapolationState* /*extrapol*/) const
 {
-  ATH_MSG_VERBOSE(
+  FCS_MSG_VERBOSE(
       "now in TFCSInvisibleParametrization::simulate(). Don't do "
       "anything for invisible");
   return FCSSuccess;

--- a/source/Core/TFCSLateralShapeParametrization.cxx
+++ b/source/Core/TFCSLateralShapeParametrization.cxx
@@ -38,18 +38,18 @@ bool TFCSLateralShapeParametrization::compare(
     const TFCSParametrizationBase& ref) const
 {
   if (IsA() != ref.IsA()) {
-    ATH_MSG_DEBUG("compare(): different class types "
+    FCS_MSG_DEBUG("compare(): different class types "
                   << IsA()->GetName() << " != " << ref.IsA()->GetName());
     return false;
   }
   const TFCSLateralShapeParametrization& ref_typed =
       static_cast<const TFCSLateralShapeParametrization&>(ref);
   if (Ekin_bin() != ref_typed.Ekin_bin()) {
-    ATH_MSG_DEBUG("compare(): different Ekin bin");
+    FCS_MSG_DEBUG("compare(): different Ekin bin");
     return false;
   }
   if (calosample() != ref_typed.calosample()) {
-    ATH_MSG_DEBUG("compare(): different calosample");
+    FCS_MSG_DEBUG("compare(): different calosample");
     return false;
   }
 
@@ -60,15 +60,16 @@ void TFCSLateralShapeParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSParametrization::Print(option);
   if (longprint) {
     if (Ekin_bin() == -1)
-      ATH_MSG_INFO(optprint << "  Ekin_bin=all ; calosample=" << calosample());
+      FCS_MSG_INFO(optprint << "  Ekin_bin=all ; calosample=" << calosample());
     else
-      ATH_MSG_INFO(optprint << "  Ekin_bin=" << Ekin_bin()
+      FCS_MSG_INFO(optprint << "  Ekin_bin=" << Ekin_bin()
                             << " ; calosample=" << calosample());
   }
 }

--- a/source/Core/TFCSLateralShapeParametrizationFluctChain.cxx
+++ b/source/Core/TFCSLateralShapeParametrizationFluctChain.cxx
@@ -50,14 +50,14 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
     const TFCSTruthState* truth,
     const TFCSExtrapolationState* extrapol) const
 {
-  MSG::Level old_level = level();
-  const bool debug = msgLvl(MSG::DEBUG);
+  FCS_MSG::Level old_level = level();
+  const bool debug = msgLvl(FCS_MSG::DEBUG);
 
   // Execute the first get_nr_of_init() simulate calls only once. Used for
   // example to initialize the center position
   TFCSLateralShapeParametrizationHitBase::Hit hit;
   if (init_hit(hit, simulstate, truth, extrapol) != FCSSuccess) {
-    ATH_MSG_ERROR("init_hit() failed");
+    FCS_MSG_ERROR("init_hit() failed");
     return FCSFatal;
   }
 
@@ -65,14 +65,14 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
   // energy
   const float Elayer = simulstate.E(calosample());
   if (Elayer == 0) {
-    ATH_MSG_VERBOSE("Elayer=0, nothing to do");
+    FCS_MSG_VERBOSE("Elayer=0, nothing to do");
     return FCSSuccess;
   }
 
   // Call get_sigma2_fluctuation only once, as it could contain a random number
   float sigma2 = get_sigma2_fluctuation(simulstate, truth, extrapol);
   if (sigma2 >= s_max_sigma2_fluctuation) {
-    ATH_MSG_ERROR(
+    FCS_MSG_ERROR(
         "TFCSLateralShapeParametrizationFluctChain::simulate(): "
         "fluctuation of hits could not be calculated");
     return FCSFatal;
@@ -93,7 +93,7 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
 
   if (debug) {
     PropagateMSGLevel(old_level);
-    ATH_MSG_DEBUG("E(" << calosample() << ")=" << Elayer
+    FCS_MSG_DEBUG("E(" << calosample() << ")=" << Elayer
                        << " sigma2=" << sigma2);
   }
 
@@ -114,7 +114,7 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
     if (debug)
       if (ihit == 2) {
         // Switch debug output back to INFO to avoid huge logs
-        PropagateMSGLevel(MSG::INFO);
+        PropagateMSGLevel(FCS_MSG::INFO);
       }
     for (auto hititr = hitloopstart; hititr != m_chain.end(); ++hititr) {
       TFCSLateralShapeParametrizationHitBase* hitsim = *hititr;
@@ -149,7 +149,7 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
         error2 = error2_sumEhit / sumEhit2;
     } else {
       if (ifail >= retry) {
-        ATH_MSG_ERROR(
+        FCS_MSG_ERROR(
             "TFCSLateralShapeParametrizationFluctChain::simulate(): "
             "simulate_hit call failed after "
             << ifail << "/" << retry << "retries, total fails=" << itotalfail);
@@ -158,7 +158,7 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
         return FCSFatal;
       }
       if (ifail >= retry_warning) {
-        ATH_MSG_WARNING(
+        FCS_MSG_WARNING(
             "TFCSLateralShapeParametrizationFluctChain::simulate():"
             " retry simulate_hit calls "
             << ifail << "/" << retry << ", total fails=" << itotalfail);
@@ -168,7 +168,7 @@ FCSReturnCode TFCSLateralShapeParametrizationFluctChain::simulate(
 
   if (debug) {
     PropagateMSGLevel(old_level);
-    ATH_MSG_DEBUG("E(" << calosample() << ")=" << Elayer << " sumE=" << sumEhit
+    FCS_MSG_DEBUG("E(" << calosample() << ")=" << Elayer << " sumE=" << sumEhit
                        << "+-" << TMath::Sqrt(error2_sumEhit) << " ~ "
                        << TMath::Sqrt(error2_sumEhit) / sumEhit * 100
                        << "% rel error^2=" << error2 << " sigma^2=" << sigma2
@@ -183,13 +183,14 @@ void TFCSLateralShapeParametrizationFluctChain::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitChain::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  hit energy fluctuation RMS=" << m_RMS);
+    FCS_MSG_INFO(optprint << "  hit energy fluctuation RMS=" << m_RMS);
 }
 
 #pragma GCC diagnostic pop

--- a/source/Core/TFCSLateralShapeParametrizationHitChain.cxx
+++ b/source/Core/TFCSLateralShapeParametrizationHitChain.cxx
@@ -84,7 +84,7 @@ void TFCSLateralShapeParametrizationHitChain::set_daughter(
   TFCSLateralShapeParametrizationHitBase* param_typed = nullptr;
   if (param != nullptr) {
     if (!param->InheritsFrom(TFCSLateralShapeParametrizationHitBase::Class())) {
-      ATH_MSG_ERROR("Wrong class type " << param->IsA()->GetName());
+      FCS_MSG_ERROR("Wrong class type " << param->IsA()->GetName());
       return;
     }
     param_typed = static_cast<TFCSLateralShapeParametrizationHitBase*>(param);
@@ -184,7 +184,7 @@ float TFCSLateralShapeParametrizationHitChain::get_sigma2_fluctuation(
 }
 
 void TFCSLateralShapeParametrizationHitChain::PropagateMSGLevel(
-    MSG::Level level) const
+    FCS_MSG::Level level) const
 {
   for (TFCSLateralShapeParametrizationHitBase* reset : m_chain)
     reset->setLevel(level);
@@ -198,7 +198,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::init_hit(
 {
   hit.reset_center();
   if (get_nr_of_init() > 0) {
-    ATH_MSG_DEBUG("E(" << calosample() << ")=" << simulstate.E(calosample())
+    FCS_MSG_DEBUG("E(" << calosample() << ")=" << simulstate.E(calosample())
                        << " before init");
 
     auto initloopend = m_chain.begin() + get_nr_of_init();
@@ -209,7 +209,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::init_hit(
           hitsim->simulate_hit(hit, simulstate, truth, extrapol);
 
       if (status != FCSSuccess) {
-        ATH_MSG_ERROR(
+        FCS_MSG_ERROR(
             "TFCSLateralShapeParametrizationHitChain::simulate(): "
             "simulate_hit init call failed");
         return FCSFatal;
@@ -224,15 +224,15 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
     const TFCSTruthState* truth,
     const TFCSExtrapolationState* extrapol) const
 {
-  MSG::Level old_level = level();
-  const bool debug = msgLvl(MSG::DEBUG);
-  const bool verbose = msgLvl(MSG::VERBOSE);
+  FCS_MSG::Level old_level = level();
+  const bool debug = msgLvl(FCS_MSG::DEBUG);
+  const bool verbose = msgLvl(FCS_MSG::VERBOSE);
 
   // Execute the first get_nr_of_init() simulate calls only once. Used for
   // example to initialize the center position
   TFCSLateralShapeParametrizationHitBase::Hit hit;
   if (init_hit(hit, simulstate, truth, extrapol) != FCSSuccess) {
-    ATH_MSG_ERROR("init_hit() failed");
+    FCS_MSG_ERROR("init_hit() failed");
     return FCSFatal;
   }
 
@@ -241,12 +241,12 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
   // energy
   const float Elayer = simulstate.E(cs);
   if (Elayer == 0) {
-    ATH_MSG_VERBOSE("Elayer=0, nothing to do");
+    FCS_MSG_VERBOSE("Elayer=0, nothing to do");
     return FCSSuccess;
   }
   const float Ehit = get_E_hit(simulstate, truth, extrapol);
   if (Ehit * Elayer <= 0) {
-    ATH_MSG_ERROR(
+    FCS_MSG_ERROR(
         "TFCSLateralShapeParametrizationHitChain::simulate(): Ehit "
         "and Elayer have different sign! Ehit="
         << Ehit << " Elayer=" << Elayer);
@@ -263,7 +263,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
 
   if (debug) {
     PropagateMSGLevel(old_level);
-    ATH_MSG_DEBUG("E(" << cs << ")=" << simulstate.E(cs) << " #hits~" << nhit);
+    FCS_MSG_DEBUG("E(" << cs << ")=" << simulstate.E(cs) << " #hits~" << nhit);
   }
 
   {
@@ -282,7 +282,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
           if (!verbose) {
             // Switch debug output back to INFO to avoid huge logs, but keep
             // full log in verbose
-            PropagateMSGLevel(MSG::INFO);
+            PropagateMSGLevel(FCS_MSG::INFO);
           }
       for (auto hititr = hitloopstart; hititr != m_chain.end(); ++hititr) {
         TFCSLateralShapeParametrizationHitBase* hitsim = *hititr;
@@ -312,13 +312,13 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
         ++ihit;
 
         if (((ihit == 20 * nhit) || (ihit == 100 * nhit)) && ihit >= 100) {
-          ATH_MSG_DEBUG(
+          FCS_MSG_DEBUG(
               "TFCSLateralShapeParametrizationHitChain::simulate(): Iterated "
               << ihit << " times, expected " << nhit << " times. Deposited E("
               << cs << ")=" << sumEhit << " expected E=" << Elayer);
         }
         if (ihit >= 1000 * nhit && ihit >= 1000) {
-          ATH_MSG_DEBUG(
+          FCS_MSG_DEBUG(
               "TFCSLateralShapeParametrizationHitChain::simulate():"
               " Aborting hit chain, iterated "
               << ihit << " times, expected " << nhit << " times. Deposited E("
@@ -330,7 +330,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
         }
       } else {
         if (ifail >= retry) {
-          ATH_MSG_ERROR(
+          FCS_MSG_ERROR(
               "TFCSLateralShapeParametrizationHitChain::simulate(): "
               "simulate_hit call failed after "
               << ifail << "/" << retry
@@ -340,7 +340,7 @@ FCSReturnCode TFCSLateralShapeParametrizationHitChain::simulate(
           return FCSFatal;
         }
         if (ifail >= retry_warning) {
-          ATH_MSG_WARNING(
+          FCS_MSG_WARNING(
               "TFCSLateralShapeParametrizationHitChain::simulate():"
               " retry simulate_hit calls "
               << ifail << "/" << retry << ", total fails=" << itotalfail);
@@ -359,24 +359,25 @@ void TFCSLateralShapeParametrizationHitChain::Print(Option_t* option) const
   TFCSLateralShapeParametrization::Print(option);
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
 
   if (m_number_of_hits_simul) {
     if (longprint)
-      ATH_MSG_INFO(optprint << "#:Number of hits simulation:");
+      FCS_MSG_INFO(optprint << "#:Number of hits simulation:");
     m_number_of_hits_simul->Print(opt + "#:");
   }
   if (longprint && get_nr_of_init() > 0)
-    ATH_MSG_INFO(optprint << "> Simulation init chain:");
+    FCS_MSG_INFO(optprint << "> Simulation init chain:");
   auto hitloopstart = m_chain.begin() + get_nr_of_init();
   for (auto hititr = m_chain.begin(); hititr != hitloopstart; ++hititr) {
     TFCSLateralShapeParametrizationHitBase* hitsim = *hititr;
     hitsim->Print(opt + "> ");
   }
   if (longprint)
-    ATH_MSG_INFO(optprint << "- Simulation chain:");
+    FCS_MSG_INFO(optprint << "- Simulation chain:");
   char count = 'A';
   for (auto hititr = hitloopstart; hititr != m_chain.end(); ++hititr) {
     TFCSLateralShapeParametrizationHitBase* hitsim = *hititr;

--- a/source/Core/TFCSLateralShapeParametrizationHitNumberFromE.cxx
+++ b/source/Core/TFCSLateralShapeParametrizationHitNumberFromE.cxx
@@ -54,7 +54,7 @@ double TFCSLateralShapeParametrizationHitNumberFromE::get_sigma2_fluctuation(
   }
 
   if (TMath::IsNaN(energy)) {
-    ATH_MSG_DEBUG("Energy is NaN");
+    FCS_MSG_DEBUG("Energy is NaN");
     return 1;
   }
 
@@ -70,7 +70,7 @@ double TFCSLateralShapeParametrizationHitNumberFromE::get_sigma2_fluctuation(
   double sigma2 =
       sigma_stochastic * sigma_stochastic + sigma_hadron * sigma_hadron;
 
-  ATH_MSG_DEBUG("sigma^2 fluctuation=" << sigma2);
+  FCS_MSG_DEBUG("sigma^2 fluctuation=" << sigma2);
 
   return sigma2;
 }
@@ -87,7 +87,7 @@ int TFCSLateralShapeParametrizationHitNumberFromE::get_number_of_hits(
   float sigma2 = get_sigma2_fluctuation(simulstate, truth, extrapol);
   int hits = CLHEP::RandPoisson::shoot(simulstate.randomEngine(), 1.0 / sigma2);
 
-  ATH_MSG_DEBUG("#hits=" << hits);
+  FCS_MSG_DEBUG("#hits=" << hits);
 
   return hits;
 }
@@ -110,7 +110,7 @@ bool TFCSLateralShapeParametrizationHitNumberFromE::compare(
     const TFCSParametrizationBase& ref) const
 {
   if (IsA() != ref.IsA()) {
-    ATH_MSG_DEBUG("compare(): different class types "
+    FCS_MSG_DEBUG("compare(): different class types "
                   << IsA()->GetName() << " != " << ref.IsA()->GetName());
     return false;
   }
@@ -120,7 +120,7 @@ bool TFCSLateralShapeParametrizationHitNumberFromE::compare(
       || m_stochastic_hadron != ref_typed.m_stochastic_hadron
       || m_constant != ref_typed.m_constant)
   {
-    ATH_MSG_DEBUG("operator==(): different fluctuation model sigma^2=["
+    FCS_MSG_DEBUG("operator==(): different fluctuation model sigma^2=["
                   << m_stochastic << "/sqrt(E/GeV)]^2 + [" << m_constant
                   << " + " << m_stochastic_hadron
                   << "/sqrt(E/GeV)]^2 != sigma^2=[" << ref_typed.m_stochastic
@@ -137,13 +137,14 @@ void TFCSLateralShapeParametrizationHitNumberFromE::Print(
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  sigma^2=[" << m_stochastic
+    FCS_MSG_INFO(optprint << "  sigma^2=[" << m_stochastic
                           << "/sqrt(E/GeV)]^2 + [" << m_constant << " + "
                           << m_stochastic_hadron << "/sqrt(E/GeV)]^2");
 }

--- a/source/Core/TFCSLateralShapeTuning.cxx
+++ b/source/Core/TFCSLateralShapeTuning.cxx
@@ -65,7 +65,7 @@ FCSReturnCode TFCSLateralShapeTuning::initFromModelFile(
       m_parameterInterpol.insert(
           std::make_pair(parameterName, linModelInterpol));
     } else {
-      ATH_MSG_DEBUG(
+      FCS_MSG_DEBUG(
           "[TFCSLateralShapeTuning] Could not find model parameter "
           "graph for layer="
           << layer << " minEta=" << intMinEta << " maxEta=" << intMaxEta);
@@ -80,7 +80,7 @@ FCSReturnCode TFCSLateralShapeTuning::initFromModelFile(
 FCSReturnCode TFCSLateralShapeTuning::initFromMap(
     const interpolationMap& interpolationMap)
 {
-  ATH_MSG_DEBUG(
+  FCS_MSG_DEBUG(
       "[TFCSLateralShapeTuning] Initializing data tuning model from "
       "interpolation map.");
   m_parameterInterpol = interpolationMap;
@@ -115,11 +115,11 @@ FCSReturnCode TFCSLateralShapeTuning::simulate_hit(
   // retrieve calo sample
   int layer = TFCSLateralShapeParametrization::calosample();
 
-  ATH_MSG_DEBUG("[TFCSLateralShapeTuning] Initializing with pdgId="
+  FCS_MSG_DEBUG("[TFCSLateralShapeTuning] Initializing with pdgId="
                 << pdgId << ", charge=" << charge << ", Ekin=" << Ekin
                 << ", caloSample=" << layer);
 
-  ATH_MSG_DEBUG("[TFCSLateralShapeTuning] Got hit position: "
+  FCS_MSG_DEBUG("[TFCSLateralShapeTuning] Got hit position: "
                 << " hit.eta=" << hit.eta() << ", hit.phi=" << hit.phi()
                 << ", hit.r=" << hit.r());
 
@@ -137,7 +137,7 @@ FCSReturnCode TFCSLateralShapeTuning::simulate_hit(
     phiScaleFactor =
         std::abs(phiScaleFactor) < maxScaling ? phiScaleFactor : maxScaling;
 
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[TFCSLateralShapeTuning] Applying 2D eta_s - eta_phi "
         "scaling model with eta_s="
         << etaScaleFactor << " and phi_s=" << phiScaleFactor);
@@ -163,7 +163,7 @@ FCSReturnCode TFCSLateralShapeTuning::simulate_hit(
     etaScaleFactor =
         std::abs(etaScaleFactor) < maxScaling ? etaScaleFactor : maxScaling;
 
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[TFCSLateralShapeTuning] Applying eta_s series expansion "
         "model with eta_s="
         << etaScaleFactor);

--- a/source/Core/TFCSNetworkFactory.cxx
+++ b/source/Core/TFCSNetworkFactory.cxx
@@ -14,7 +14,6 @@
 
 // For messaging
 #include "FastCaloSim/Core/MLogging.h"
-using ISF_FCS::MLogging;
 
 void TFCSNetworkFactory::resolveGlobs(std::string& filename)
 {
@@ -23,11 +22,11 @@ void TFCSNetworkFactory::resolveGlobs(std::string& filename)
   const int ending_len = ending.length();
   const int filename_len = filename.length();
   if (filename_len < ending_len) {
-    ATH_MSG_NOCLASS(logger, "Filename is implausably short.");
+    FCS_MSG_NOCLASS(logger, "Filename is implausably short.");
   } else if (0
              == filename.compare(filename_len - ending_len, ending_len, ending))
   {
-    ATH_MSG_NOCLASS(logger, "Filename ends in glob.");
+    FCS_MSG_NOCLASS(logger, "Filename ends in glob.");
     // Remove the glob
     filename.pop_back();
     if (std::filesystem::exists(filename + "onnx")) {
@@ -61,7 +60,7 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(
     std::vector<char> const& input)
 {
   ISF_FCS::MLogging logger;
-  ATH_MSG_NOCLASS(
+  FCS_MSG_NOCLASS(
       logger,
       "Directly creating ONNX network from bytes length " << input.size());
   std::unique_ptr<VNetworkBase> created(new TFCSONNXHandler(input));
@@ -73,7 +72,7 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(std::string input)
   ISF_FCS::MLogging logger;
   resolveGlobs(input);
   if (VNetworkBase::isFile(input) && isOnnxFile(input)) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Creating ONNX network from file ..."
                         << input.substr(input.length() - 10));
     std::unique_ptr<VNetworkBase> created(new TFCSONNXHandler(input));
@@ -81,14 +80,14 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(std::string input)
   } else {
     try {
       std::unique_ptr<VNetworkBase> created(new TFCSSimpleLWTNNHandler(input));
-      ATH_MSG_NOCLASS(logger,
+      FCS_MSG_NOCLASS(logger,
                       "Succeeded in creating LWTNN nn from string starting "
                           << input.substr(0, 10));
       return created;
     } catch (const boost::property_tree::ptree_bad_path& e) {
       // If we get this error, it was actually a graph, not a NeuralNetwork
       std::unique_ptr<VNetworkBase> created(new TFCSGANLWTNNHandler(input));
-      ATH_MSG_NOCLASS(logger, "Succeeded in creating LWTNN graph from string");
+      FCS_MSG_NOCLASS(logger, "Succeeded in creating LWTNN graph from string");
       return created;
     };
   };
@@ -100,18 +99,18 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(std::string input,
   ISF_FCS::MLogging logger;
   resolveGlobs(input);
   if (VNetworkBase::isFile(input) && isOnnxFile(input)) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Creating ONNX network from file ..."
                         << input.substr(input.length() - 10));
     std::unique_ptr<VNetworkBase> created(new TFCSONNXHandler(input));
     return created;
   } else if (graph_form) {
-    ATH_MSG_NOCLASS(logger, "Creating LWTNN graph from string");
+    FCS_MSG_NOCLASS(logger, "Creating LWTNN graph from string");
     std::unique_ptr<VNetworkBase> created(new TFCSGANLWTNNHandler(input));
     return created;
   } else {
     std::unique_ptr<VNetworkBase> created(new TFCSSimpleLWTNNHandler(input));
-    ATH_MSG_NOCLASS(logger, "Creating LWTNN nn from string");
+    FCS_MSG_NOCLASS(logger, "Creating LWTNN nn from string");
     return created;
   };
 };
@@ -120,15 +119,15 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(
     std::vector<char> const& vector_input, std::string string_input)
 {
   ISF_FCS::MLogging logger;
-  ATH_MSG_NOCLASS(logger, "Given both bytes and a string to create an nn.");
+  FCS_MSG_NOCLASS(logger, "Given both bytes and a string to create an nn.");
   resolveGlobs(string_input);
   if (vector_input.size() > 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Bytes contains data, size=" << vector_input.size()
                                                  << ", creating from bytes.");
     return create(vector_input);
   } else if (string_input.length() > 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "No data in bytes, string contains data, "
                         << "creating from string.");
     return create(string_input);
@@ -144,17 +143,17 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(
     bool graph_form)
 {
   ISF_FCS::MLogging logger;
-  ATH_MSG_NOCLASS(
+  FCS_MSG_NOCLASS(
       logger,
       "Given both bytes, a string and graph form specified to create an nn.");
   resolveGlobs(string_input);
   if (vector_input.size() > 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "Bytes contains data, size=" << vector_input.size()
                                                  << ", creating from bytes.");
     return create(vector_input);
   } else if (string_input.length() > 0) {
-    ATH_MSG_NOCLASS(logger,
+    FCS_MSG_NOCLASS(logger,
                     "No data in bytes, string contains data, "
                         << "creating from string.");
     return create(string_input, graph_form);

--- a/source/Core/TFCSPCAEnergyParametrization.cxx
+++ b/source/Core/TFCSPCAEnergyParametrization.cxx
@@ -49,20 +49,21 @@ void TFCSPCAEnergyParametrization::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSEnergyParametrization::Print(option);
 
   if (longprint) {
-    ATH_MSG(INFO) << optprint << "  #bins=" << m_numberpcabins
+    FCS_MSG(INFO) << optprint << "  #bins=" << m_numberpcabins
                   << ", Enorm=" << m_total_energy_normalization << ", layers=";
     for (unsigned int i = 0; i < m_RelevantLayers.size(); i++) {
       if (i > 0)
-        ATH_MSG(INFO) << ", ";
-      ATH_MSG(INFO) << m_RelevantLayers[i];
+        FCS_MSG(INFO) << ", ";
+      FCS_MSG(INFO) << m_RelevantLayers[i];
     }
-    ATH_MSG(INFO) << END_MSG(INFO);
+    FCS_MSG(INFO) << END_FCS_MSG(INFO);
   }
 }
 
@@ -218,7 +219,7 @@ FCSReturnCode TFCSPCAEnergyParametrization::simulate(
     double total_energy =
         simdata[layerNr.size()] * simulstate.E() / m_total_energy_normalization;
     simulstate.set_E(total_energy);
-    ATH_MSG_DEBUG("set E to total_energy=" << total_energy);
+    FCS_MSG_DEBUG("set E to total_energy=" << total_energy);
 
     for (int s = 0; s < m_geo->n_layers(); s++) {
       double energyfrac = 0.0;
@@ -290,7 +291,7 @@ bool TFCSPCAEnergyParametrization::loadInputs(TFile* file,
   file->cd(x + "1/pca");
   IntArray* RelevantLayers = (IntArray*)gDirectory->Get("RelevantLayers");
   if (RelevantLayers == nullptr) {
-    ATH_MSG_ERROR(
+    FCS_MSG_ERROR(
         "TFCSPCAEnergyParametrization::m_RelevantLayers in first "
         "pcabin is null!");
     load_ok = false;
@@ -313,27 +314,27 @@ bool TFCSPCAEnergyParametrization::loadInputs(TFile* file,
     TVectorD* Gauss_rms = (TVectorD*)gDirectory->Get("Gauss_rms");
 
     if (symCov == nullptr) {
-      ATH_MSG_WARNING("TFCSPCAEnergyParametrization::symCov in pcabin "
+      FCS_MSG_WARNING("TFCSPCAEnergyParametrization::symCov in pcabin "
                       << bin << " is null!");
       load_ok = false;
     }
     if (MeanValues == nullptr) {
-      ATH_MSG_WARNING("TFCSPCAEnergyParametrization::MeanValues in pcabin "
+      FCS_MSG_WARNING("TFCSPCAEnergyParametrization::MeanValues in pcabin "
                       << bin << " is null!");
       load_ok = false;
     }
     if (SigmaValues == nullptr) {
-      ATH_MSG_WARNING("TFCSPCAEnergyParametrization::SigmaValues in pcabin "
+      FCS_MSG_WARNING("TFCSPCAEnergyParametrization::SigmaValues in pcabin "
                       << bin << " is null!");
       load_ok = false;
     }
     if (Gauss_means == nullptr) {
-      ATH_MSG_WARNING("TFCSPCAEnergyParametrization::Gauss_means in pcabin "
+      FCS_MSG_WARNING("TFCSPCAEnergyParametrization::Gauss_means in pcabin "
                       << bin << " is null!");
       load_ok = false;
     }
     if (Gauss_rms == nullptr) {
-      ATH_MSG_WARNING("TFCSPCAEnergyParametrization::Gause_rms in pcabin "
+      FCS_MSG_WARNING("TFCSPCAEnergyParametrization::Gause_rms in pcabin "
                       << bin << " is null!");
       load_ok = false;
     }

--- a/source/Core/TFCSParametrization.cxx
+++ b/source/Core/TFCSParametrization.cxx
@@ -113,38 +113,38 @@ void TFCSParametrization::set_pdgid_Ekin_eta(const TFCSParametrizationBase& ref)
 bool TFCSParametrization::compare(const TFCSParametrizationBase& ref) const
 {
   if (IsA() != ref.IsA()) {
-    ATH_MSG_DEBUG("compare(): different class types "
+    FCS_MSG_DEBUG("compare(): different class types "
                   << IsA()->GetName() << " != " << ref.IsA()->GetName());
     return false;
   }
   std::string name(GetName());
   if (name != ref.GetName()) {
-    ATH_MSG_DEBUG("compare(): different names " << GetName()
+    FCS_MSG_DEBUG("compare(): different names " << GetName()
                                                 << " != " << ref.GetName());
     return false;
   }
   std::string title(GetTitle());
   if (title != ref.GetTitle()) {
-    ATH_MSG_DEBUG("compare(): different titles " << GetTitle()
+    FCS_MSG_DEBUG("compare(): different titles " << GetTitle()
                                                  << " != " << ref.GetTitle());
     return false;
   }
   if (is_match_all_pdgid() != ref.is_match_all_pdgid()
       || pdgid() != ref.pdgid())
   {
-    ATH_MSG_DEBUG("compare(): different pdgids");
+    FCS_MSG_DEBUG("compare(): different pdgids");
     return false;
   }
   if (Ekin_nominal() != ref.Ekin_nominal() || Ekin_min() != ref.Ekin_min()
       || Ekin_max() != ref.Ekin_max())
   {
-    ATH_MSG_DEBUG("compare(): different Ekin range");
+    FCS_MSG_DEBUG("compare(): different Ekin range");
     return false;
   }
   if (eta_nominal() != ref.eta_nominal() || eta_min() != ref.eta_min()
       || eta_max() != ref.eta_max())
   {
-    ATH_MSG_DEBUG("compare(): different eta range");
+    FCS_MSG_DEBUG("compare(): different eta range");
     return false;
   }
 

--- a/source/Core/TFCSParametrizationBase.cxx
+++ b/source/Core/TFCSParametrizationBase.cxx
@@ -29,7 +29,7 @@ FCSReturnCode TFCSParametrizationBase::simulate(
     const TFCSTruthState* /*truth*/,
     const TFCSExtrapolationState* /*extrapol*/) const
 {
-  ATH_MSG_ERROR(
+  FCS_MSG_ERROR(
       "now in TFCSParametrizationBase::simulate(). This should "
       "normally not happen");
   // Force one retry to issue a printout from the chain causing the call to this
@@ -40,7 +40,7 @@ FCSReturnCode TFCSParametrizationBase::simulate(
 bool TFCSParametrizationBase::compare(const TFCSParametrizationBase& ref) const
 {
   if (this == &ref) {
-    ATH_MSG_DEBUG("compare(): identical instances " << this << " == " << &ref);
+    FCS_MSG_DEBUG("compare(): identical instances " << this << " == " << &ref);
     return true;
   }
   return false;
@@ -51,39 +51,40 @@ void TFCSParametrizationBase::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
 
   if (longprint) {
-    ATH_MSG_INFO(optprint << GetTitle() << " " << IsA()->GetName());
-    ATH_MSG(INFO) << optprint << "  PDGID: ";
+    FCS_MSG_INFO(optprint << GetTitle() << " " << IsA()->GetName());
+    FCS_MSG(INFO) << optprint << "  PDGID: ";
     if (is_match_all_pdgid()) {
-      ATH_MSG(INFO) << "all";
+      FCS_MSG(INFO) << "all";
     } else {
       for (std::set<int>::iterator it = pdgid().begin(); it != pdgid().end();
            ++it)
       {
         if (it != pdgid().begin())
-          ATH_MSG(INFO) << ", ";
-        ATH_MSG(INFO) << *it;
+          FCS_MSG(INFO) << ", ";
+        FCS_MSG(INFO) << *it;
       }
     }
     if (is_match_all_Ekin()) {
-      ATH_MSG(INFO) << " ; Ekin=all";
+      FCS_MSG(INFO) << " ; Ekin=all";
     } else {
-      ATH_MSG(INFO) << " ; Ekin=" << Ekin_nominal() << " [" << Ekin_min()
+      FCS_MSG(INFO) << " ; Ekin=" << Ekin_nominal() << " [" << Ekin_min()
                     << " , " << Ekin_max() << ") MeV";
     }
     if (is_match_all_eta()) {
-      ATH_MSG(INFO) << " ; eta=all";
+      FCS_MSG(INFO) << " ; eta=all";
     } else {
-      ATH_MSG(INFO) << " ; eta=" << eta_nominal() << " [" << eta_min() << " , "
+      FCS_MSG(INFO) << " ; eta=" << eta_nominal() << " [" << eta_min() << " , "
                     << eta_max() << ")";
     }
-    ATH_MSG(INFO) << END_MSG(INFO);
+    FCS_MSG(INFO) << END_FCS_MSG(INFO);
   } else {
-    ATH_MSG_INFO(optprint << GetTitle());
+    FCS_MSG_INFO(optprint << GetTitle());
   }
 }
 
@@ -96,11 +97,11 @@ void TFCSParametrizationBase::FindDuplicates(FindDuplicateClasses_t& dupclasses)
       // If param is already in the duplication list, skip over
       auto checkexist = dup.find(param);
       if (checkexist != dup.end()) {
-        ATH_MSG_DEBUG("Found duplicate pointer for: " << param << "="
+        FCS_MSG_DEBUG("Found duplicate pointer for: " << param << "="
                                                       << param->GetName());
         if (checkexist->second.replace) {
           TFCSParametrizationBase* refparam = checkexist->second.replace;
-          ATH_MSG_DEBUG("Found duplicate pointer: "
+          FCS_MSG_DEBUG("Found duplicate pointer: "
                         << refparam << "=" << refparam->GetName()
                         << ", duplicate is " << param << "=" << param->GetName()
                         << " index " << i << " of " << this);
@@ -124,7 +125,7 @@ void TFCSParametrizationBase::FindDuplicates(FindDuplicateClasses_t& dupclasses)
           continue;
         // Check for objects with identical content
         if (*param == *refparam) {
-          ATH_MSG_DEBUG("Found duplicate: "
+          FCS_MSG_DEBUG("Found duplicate: "
                         << refparam << "=" << refparam->GetName()
                         << ", duplicate is " << param << "=" << param->GetName()
                         << " index " << i << " of " << this);
@@ -151,21 +152,21 @@ void TFCSParametrizationBase::RemoveDuplicates()
       if (onedup.second.mother.empty())
         continue;
       TFCSParametrizationBase* ref = onedup.first;
-      ATH_MSG_DEBUG("Main object " << ref << "=" << ref->GetName());
+      FCS_MSG_DEBUG("Main object " << ref << "=" << ref->GetName());
       for (unsigned int i = 0; i < onedup.second.mother.size(); ++i) {
         int index = onedup.second.index[i];
         TFCSParametrizationBase* mother = onedup.second.mother[i];
         TFCSParametrizationBase* delparam = mother->operator[](index);
         unsigned int delcount = dup[delparam].mother.size();
         if (delcount == 0) {
-          ATH_MSG_DEBUG("  - Delete object "
+          FCS_MSG_DEBUG("  - Delete object "
                         << delparam << "=" << delparam->GetName() << " index "
                         << index << " of " << mother << ", has " << delcount
                         << " other replacements attached. Deleting");
           mother->set_daughter(index, ref);
           dellist.insert(delparam);
         } else {
-          ATH_MSG_WARNING("  - Delete object "
+          FCS_MSG_WARNING("  - Delete object "
                           << delparam << "=" << delparam->GetName() << " index "
                           << index << " of " << mother << ", has " << delcount
                           << " other replacements attached. Skipping");
@@ -174,7 +175,7 @@ void TFCSParametrizationBase::RemoveDuplicates()
     }
   }
 
-  ATH_MSG_INFO("RERUNNING DUPLICATE FINDING");
+  FCS_MSG_INFO("RERUNNING DUPLICATE FINDING");
   FindDuplicateClasses_t dupclasses2;
   FindDuplicates(dupclasses2);
 
@@ -183,18 +184,18 @@ void TFCSParametrizationBase::RemoveDuplicates()
     FindDuplicates_t& dup2 = dupclasses2[delparam->GetName()];
     bool present = dup2.find(delparam) != dup2.end();
     if (present) {
-      ATH_MSG_WARNING("- Delete object " << delparam << "="
+      FCS_MSG_WARNING("- Delete object " << delparam << "="
                                          << delparam->GetName()
                                          << " still referenced somewhere!");
     } else {
-      ATH_MSG_DEBUG("- Delete object " << delparam << "="
+      FCS_MSG_DEBUG("- Delete object " << delparam << "="
                                        << delparam->GetName());
       ++ndel[delparam->ClassName()];
       delete delparam;
     }
   }
   for (auto& del : ndel)
-    ATH_MSG_INFO("Deleted " << del.second << " duplicate objects of class "
+    FCS_MSG_INFO("Deleted " << del.second << " duplicate objects of class "
                             << del.first);
 }
 

--- a/source/Core/TFCSParametrizationBinnedChain.cxx
+++ b/source/Core/TFCSParametrizationBinnedChain.cxx
@@ -75,12 +75,12 @@ FCSReturnCode TFCSParametrizationBinnedChain::simulate(
   FCSReturnCode status = FCSSuccess;
   for (int i = 0; i <= retry; i++) {
     if (i >= retry_warning)
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "TFCSParametrizationBinnedChain::simulate(): Retry simulate call "
           << i << "/" << retry);
 
     for (unsigned int ichain = 0; ichain < m_bin_start[0]; ++ichain) {
-      ATH_MSG_DEBUG("now run for all bins: " << chain()[ichain]->GetName());
+      FCS_MSG_DEBUG("now run for all bins: " << chain()[ichain]->GetName());
       status = simulate_and_retry(chain()[ichain], simulstate, truth, extrapol);
       if (status >= FCSRetry) {
         retry = status - FCSRetry;
@@ -102,7 +102,7 @@ FCSReturnCode TFCSParametrizationBinnedChain::simulate(
              ichain < m_bin_start[bin + 1];
              ++ichain)
         {
-          ATH_MSG_DEBUG("for " << get_variable_text(simulstate, truth, extrapol)
+          FCS_MSG_DEBUG("for " << get_variable_text(simulstate, truth, extrapol)
                                << " run " << get_bin_text(bin) << ": "
                                << chain()[ichain]->GetName());
           status =
@@ -118,17 +118,17 @@ FCSReturnCode TFCSParametrizationBinnedChain::simulate(
             return FCSFatal;
         }
       } else {
-        ATH_MSG_WARNING("for " << get_variable_text(simulstate, truth, extrapol)
+        FCS_MSG_WARNING("for " << get_variable_text(simulstate, truth, extrapol)
                                << ": " << get_bin_text(bin));
       }
     } else {
-      ATH_MSG_WARNING("no bins defined, is this intended?");
+      FCS_MSG_WARNING("no bins defined, is this intended?");
     }
     if (status >= FCSRetry)
       continue;
 
     for (unsigned int ichain = m_bin_start.back(); ichain < size(); ++ichain) {
-      ATH_MSG_DEBUG("now run for all bins: " << chain()[ichain]->GetName());
+      FCS_MSG_DEBUG("now run for all bins: " << chain()[ichain]->GetName());
       status = simulate_and_retry(chain()[ichain], simulstate, truth, extrapol);
       if (status >= FCSRetry) {
         retry = status - FCSRetry;
@@ -146,7 +146,7 @@ FCSReturnCode TFCSParametrizationBinnedChain::simulate(
   }
 
   if (status != FCSSuccess) {
-    ATH_MSG_FATAL(
+    FCS_MSG_FATAL(
         "TFCSParametrizationBinnedChain::simulate(): Simulate call "
         "failed after "
         << retry << " retries");
@@ -161,7 +161,8 @@ void TFCSParametrizationBinnedChain::Print(Option_t* option) const
   TFCSParametrization::Print(option);
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
 
@@ -170,7 +171,7 @@ void TFCSParametrizationBinnedChain::Print(Option_t* option) const
     if (ichain == 0 && ichain != m_bin_start.front()) {
       prefix = "> ";
       if (longprint)
-        ATH_MSG_INFO(optprint << prefix << "Run for all bins");
+        FCS_MSG_INFO(optprint << prefix << "Run for all bins");
     }
     for (unsigned int ibin = 0; ibin < get_number_of_bins(); ++ibin) {
       if (ichain == m_bin_start[ibin]) {
@@ -179,13 +180,13 @@ void TFCSParametrizationBinnedChain::Print(Option_t* option) const
             continue;
         prefix = Form("%-2d", ibin);
         if (longprint)
-          ATH_MSG_INFO(optprint << prefix << "Run for " << get_bin_text(ibin));
+          FCS_MSG_INFO(optprint << prefix << "Run for " << get_bin_text(ibin));
       }
     }
     if (ichain == m_bin_start.back()) {
       prefix = "< ";
       if (longprint)
-        ATH_MSG_INFO(optprint << prefix << "Run for all bins");
+        FCS_MSG_INFO(optprint << prefix << "Run for all bins");
     }
     chain()[ichain]->Print(opt + prefix);
   }

--- a/source/Core/TFCSParametrizationChain.cxx
+++ b/source/Core/TFCSParametrizationChain.cxx
@@ -167,7 +167,7 @@ FCSReturnCode TFCSParametrizationChain::simulate(
   FCSReturnCode status = FCSSuccess;
   for (int i = 0; i <= retry; i++) {
     if (i >= retry_warning)
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "TFCSParametrizationChain::simulate(): Retry simulate call "
           << i << "/" << retry);
     for (const auto& param : m_chain) {
@@ -189,7 +189,7 @@ FCSReturnCode TFCSParametrizationChain::simulate(
   }
 
   if (status != FCSSuccess) {
-    ATH_MSG_FATAL(
+    FCS_MSG_FATAL(
         "TFCSParametrizationChain::simulate(): Simulate call failed after "
         << retry << " retries");
     return FCSFatal;
@@ -203,7 +203,8 @@ void TFCSParametrizationChain::Print(Option_t* option) const
   TFCSParametrization::Print(option);
   TString opt(option);
   // bool shortprint=opt.Index("short")>=0;
-  // bool longprint=msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  // bool longprint=msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) &&
+  // !shortprint);
 
   char count = 'A';
   for (const auto& param : m_chain) {

--- a/source/Core/TFCSParametrizationEkinSelectChain.cxx
+++ b/source/Core/TFCSParametrizationEkinSelectChain.cxx
@@ -82,7 +82,7 @@ int TFCSParametrizationEkinSelectChain::get_bin(
 
     if (numerator / denominator < rnd)
       bin = prevbin;
-    ATH_MSG_DEBUG("logEkin="
+    FCS_MSG_DEBUG("logEkin="
                   << logEkin << " logEkin_previous=" << logEkin_previous
                   << " logEkin_nominal=" << logEkin_nominal
                   << " (rnd=" << 1 - rnd
@@ -110,7 +110,7 @@ int TFCSParametrizationEkinSelectChain::get_bin(
 
     if (rnd < numerator / denominator)
       bin = nextbin;
-    ATH_MSG_DEBUG("logEkin="
+    FCS_MSG_DEBUG("logEkin="
                   << logEkin << " logEkin_nominal=" << logEkin_nominal
                   << " logEkin_next=" << logEkin_next << " (rnd=" << rnd
                   << " < p(next)=" << numerator / denominator

--- a/source/Core/TFCSParametrizationFloatSelectChain.cxx
+++ b/source/Core/TFCSParametrizationFloatSelectChain.cxx
@@ -17,7 +17,7 @@ int TFCSParametrizationFloatSelectChain::push_back_in_bin(
 {
   if (up < low) {
     // can't handle wrong order of bounds
-    ATH_MSG_ERROR("Cannot add " << param->GetName() << ": range [" << low << ","
+    FCS_MSG_ERROR("Cannot add " << param->GetName() << ": range [" << low << ","
                                 << up << ") not well defined");
     return -1;
   }
@@ -41,7 +41,7 @@ int TFCSParametrizationFloatSelectChain::push_back_in_bin(
 
   if (ilow < 0 && iup < 0) {
     // can't handle disjunct ranges
-    ATH_MSG_ERROR("Cannot add " << param->GetName() << ": range [" << low << ","
+    FCS_MSG_ERROR("Cannot add " << param->GetName() << ": range [" << low << ","
                                 << up << ") which is outside existing range ["
                                 << m_bin_low_edge[0] << ","
                                 << m_bin_low_edge[get_number_of_bins()] << ")");
@@ -74,7 +74,7 @@ int TFCSParametrizationFloatSelectChain::push_back_in_bin(
     return newbin;
   }
 
-  ATH_MSG_ERROR("Cannot add "
+  FCS_MSG_ERROR("Cannot add "
                 << param->GetName() << ": range [" << low << "," << up
                 << ") covers more than one bin in existing range ["
                 << m_bin_low_edge[0] << ","
@@ -96,19 +96,19 @@ void TFCSParametrizationFloatSelectChain::push_back_in_bin(
 int TFCSParametrizationFloatSelectChain::val_to_bin(float val) const
 {
   if (val < m_bin_low_edge[0]) {
-    ATH_MSG_VERBOSE("val_to_bin(" << val << ")=-1: " << val << " < "
+    FCS_MSG_VERBOSE("val_to_bin(" << val << ")=-1: " << val << " < "
                                   << m_bin_low_edge[0]);
     return -1;
   }
   if (val >= m_bin_low_edge[get_number_of_bins()]) {
-    ATH_MSG_VERBOSE("val_to_bin(" << val << ")=-1: " << val << " >= "
+    FCS_MSG_VERBOSE("val_to_bin(" << val << ")=-1: " << val << " >= "
                                   << m_bin_low_edge[get_number_of_bins()]);
     return -1;
   }
 
   auto it = std::upper_bound(m_bin_low_edge.begin(), m_bin_low_edge.end(), val);
   int dist = std::distance(m_bin_low_edge.begin(), it) - 1;
-  ATH_MSG_VERBOSE("val_to_bin(" << val << ")=" << dist);
+  FCS_MSG_VERBOSE("val_to_bin(" << val << ")=" << dist);
   return dist;
 }
 

--- a/source/Core/TFCSParametrizationPDGIDSelectChain.cxx
+++ b/source/Core/TFCSParametrizationPDGIDSelectChain.cxx
@@ -35,20 +35,20 @@ FCSReturnCode TFCSParametrizationPDGIDSelectChain::simulate(
   FCSReturnCode status = FCSSuccess;
   for (int i = 0; i <= retry; i++) {
     if (i >= retry_warning)
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "TFCSParametrizationPDGIDSelectChain::simulate(): Retry "
           "simulate call "
           << i << "/" << retry);
 
-    ATH_MSG_DEBUG("Running for pdgid=" << truth->pdgid());
+    FCS_MSG_DEBUG("Running for pdgid=" << truth->pdgid());
     for (const auto& param : chain()) {
-      ATH_MSG_DEBUG("Now testing: "
+      FCS_MSG_DEBUG("Now testing: "
                     << param->GetName()
                     << ((SimulateOnlyOnePDGID() == true)
                             ? ", abort PDGID loop afterwards"
                             : ", continue PDGID loop afterwards"));
       if (param->is_match_pdgid(truth->pdgid())) {
-        ATH_MSG_DEBUG("pdgid=" << truth->pdgid()
+        FCS_MSG_DEBUG("pdgid=" << truth->pdgid()
                                << ", now run: " << param->GetName()
                                << ((SimulateOnlyOnePDGID() == true)
                                        ? ", abort PDGID loop afterwards"
@@ -74,7 +74,7 @@ FCSReturnCode TFCSParametrizationPDGIDSelectChain::simulate(
   }
 
   if (status != FCSSuccess) {
-    ATH_MSG_FATAL(
+    FCS_MSG_FATAL(
         "TFCSParametrizationChain::simulate(): Simulate call failed after "
         << retry << " retries");
     return FCSFatal;

--- a/source/Core/TFCSParametrizationPlaceholder.cxx
+++ b/source/Core/TFCSParametrizationPlaceholder.cxx
@@ -11,7 +11,7 @@ FCSReturnCode TFCSParametrizationPlaceholder::simulate(
     const TFCSTruthState* /*truth*/,
     const TFCSExtrapolationState* /*extrapol*/) const
 {
-  ATH_MSG_ERROR(
+  FCS_MSG_ERROR(
       "TFCSParametrizationPlaceholder::simulate(). This is a "
       "placeholder and should never get called. Likely a problem in "
       "the reading of the parametrization file occurred and this "

--- a/source/Core/TFCSPredictExtrapWeights.cxx
+++ b/source/Core/TFCSPredictExtrapWeights.cxx
@@ -66,7 +66,7 @@ bool TFCSPredictExtrapWeights::operator==(
     const TFCSParametrizationBase& ref) const
 {
   if (IsA() != ref.IsA()) {
-    ATH_MSG_DEBUG("operator==: different class types "
+    FCS_MSG_DEBUG("operator==: different class types "
                   << IsA()->GetName() << " != " << ref.IsA()->GetName());
     return false;
   }
@@ -88,7 +88,7 @@ bool TFCSPredictExtrapWeights::operator==(
 bool TFCSPredictExtrapWeights::getNormInputs(
     const std::string& etaBin, const std::string& FastCaloTXTInputFolderName)
 {
-  ATH_MSG_DEBUG(" Getting normalization inputs... ");
+  FCS_MSG_DEBUG(" Getting normalization inputs... ");
 
   // Open corresponding TXT file and extract mean/std dev for each variable
   if (m_normLayers != nullptr) {
@@ -108,7 +108,7 @@ bool TFCSPredictExtrapWeights::getNormInputs(
   }
   std::string inputFileName = FastCaloTXTInputFolderName
       + "MeanStdDevEnergyFractions_eta_" + etaBin + ".txt";
-  ATH_MSG_DEBUG(" Opening " << inputFileName);
+  FCS_MSG_DEBUG(" Opening " << inputFileName);
   std::ifstream inputTXT(inputFileName);
   if (inputTXT.is_open()) {
     std::string line;
@@ -135,7 +135,7 @@ bool TFCSPredictExtrapWeights::getNormInputs(
     }
     inputTXT.close();
   } else {
-    ATH_MSG_ERROR(" Unable to open file " << inputFileName);
+    FCS_MSG_ERROR(" Unable to open file " << inputFileName);
     return false;
   }
 
@@ -162,7 +162,7 @@ std::map<std::string, double> TFCSPredictExtrapWeights::prepareInputs(
             (simulstate.Efrac(ilayer) - std::as_const(m_normMeans)->at(index))
             / std::as_const(m_normStdDevs)->at(index);
       } else {
-        ATH_MSG_ERROR("Normalization information not found for layer "
+        FCS_MSG_ERROR("Normalization information not found for layer "
                       << ilayer);
       }
     }
@@ -197,7 +197,7 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate(
     if (std::find(m_relevantLayers->cbegin(), m_relevantLayers->cend(), ilayer)
         != m_relevantLayers->cend())
     {
-      ATH_MSG_DEBUG("TFCSPredictExtrapWeights::simulate: layer: "
+      FCS_MSG_DEBUG("TFCSPredictExtrapWeights::simulate: layer: "
                     << ilayer << " weight: "
                     << outputs["extrapWeight_" + std::to_string(ilayer)]);
       float weight = outputs["extrapWeight_" + std::to_string(ilayer)];
@@ -209,7 +209,7 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate(
       }
       simulstate.setAuxInfo<float>(ilayer, weight);
     } else {  // use weight=0.5 for non-relevant layers
-      ATH_MSG_DEBUG(
+      FCS_MSG_DEBUG(
           "Setting weight=0.5 for layer = " << std::to_string(ilayer));
       simulstate.setAuxInfo<float>(ilayer, float(0.5));
     }
@@ -231,7 +231,7 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate_hit(
   if (simulstate.hasAuxInfo(cs)) {
     extrapWeight = simulstate.getAuxInfo<float>(cs);
   } else {  // missing AuxInfo
-    ATH_MSG_FATAL(
+    FCS_MSG_FATAL(
         "Simulstate is not decorated with extrapolation weights for cs = "
         << std::to_string(cs));
     return FCSFatal;
@@ -244,10 +244,10 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate_hit(
   float extrapWeight_for_r_z = extrapWeight;
   if (UseHardcodedWeight()) {
     extrapWeight_for_r_z = 0.5;
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "Will use extrapWeight=0.5 for r and z when constructing a hit");
   } else {
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "Will use predicted extrapWeight also for r and z when "
         "constructing a hit");
   }
@@ -259,10 +259,10 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate_hit(
   if (!std::isfinite(r) || !std::isfinite(z) || !std::isfinite(eta)
       || !std::isfinite(phi))
   {
-    ATH_MSG_WARNING(
+    FCS_MSG_WARNING(
         "Extrapolator contains NaN or infinite number.\nSetting "
         "center position to calo boundary.");
-    ATH_MSG_WARNING("Before fix: center_r: "
+    FCS_MSG_WARNING("Before fix: center_r: "
                     << r << " center_z: " << z << " center_phi: " << phi
                     << " center_eta: " << eta << " weight: " << extrapWeight
                     << " cs: " << cs);
@@ -271,7 +271,7 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate_hit(
     z = extrapol->IDCaloBoundary_z();
     eta = extrapol->IDCaloBoundary_eta();
     phi = extrapol->IDCaloBoundary_phi();
-    ATH_MSG_WARNING("After fix: center_r: "
+    FCS_MSG_WARNING("After fix: center_r: "
                     << r << " center_z: " << z << " center_phi: " << phi
                     << " center_eta: " << eta << " weight: " << extrapWeight
                     << " cs: " << cs);
@@ -282,7 +282,7 @@ FCSReturnCode TFCSPredictExtrapWeights::simulate_hit(
   hit.setCenter_eta(eta);
   hit.setCenter_phi(phi);
 
-  ATH_MSG_DEBUG("TFCSPredictExtrapWeights: center_r: "
+  FCS_MSG_DEBUG("TFCSPredictExtrapWeights: center_r: "
                 << hit.center_r() << " center_z: " << hit.center_z()
                 << " center_phi: " << hit.center_phi()
                 << " center_eta: " << hit.center_eta()
@@ -298,18 +298,18 @@ bool TFCSPredictExtrapWeights::initializeNetwork(
     const std::string& etaBin,
     const std::string& FastCaloNNInputFolderName)
 {
-  ATH_MSG_INFO(
+  FCS_MSG_INFO(
       "Using FastCaloNNInputFolderName: " << FastCaloNNInputFolderName);
   set_pdgid(pid);
 
   std::string inputFileName =
       FastCaloNNInputFolderName + "NN_" + etaBin + ".json";
-  ATH_MSG_DEBUG("Will read JSON file: " << inputFileName);
+  FCS_MSG_DEBUG("Will read JSON file: " << inputFileName);
   if (inputFileName.empty()) {
-    ATH_MSG_ERROR("Could not find json file " << inputFileName);
+    FCS_MSG_ERROR("Could not find json file " << inputFileName);
     return false;
   } else {
-    ATH_MSG_INFO("For pid: " << pid << " and etaBin" << etaBin
+    FCS_MSG_INFO("For pid: " << pid << " and etaBin" << etaBin
                              << ", loading json file " << inputFileName);
     std::ifstream input(inputFileName);
     std::stringstream sin;
@@ -319,7 +319,7 @@ bool TFCSPredictExtrapWeights::initializeNetwork(
     m_nn = new lwt::LightweightNeuralNetwork(
         config.inputs, config.layers, config.outputs);
     if (m_nn == nullptr) {
-      ATH_MSG_ERROR("Could not create LightWeightNeuralNetwork from "
+      FCS_MSG_ERROR("Could not create LightWeightNeuralNetwork from "
                     << inputFileName);
       return false;
     }
@@ -373,14 +373,15 @@ void TFCSPredictExtrapWeights::Print(Option_t* option) const
 {
   TString opt(option);
   bool shortprint = opt.Index("short") >= 0;
-  bool longprint = msgLvl(MSG::DEBUG) || (msgLvl(MSG::INFO) && !shortprint);
+  bool longprint =
+      msgLvl(FCS_MSG::DEBUG) || (msgLvl(FCS_MSG::INFO) && !shortprint);
   TString optprint = opt;
   optprint.ReplaceAll("short", "");
   TFCSLateralShapeParametrizationHitBase::Print(option);
 
   if (longprint)
-    ATH_MSG_INFO(optprint << "  m_input (TFCSPredictExtrapWeights): "
+    FCS_MSG_INFO(optprint << "  m_input (TFCSPredictExtrapWeights): "
                           << m_input);
   if (longprint)
-    ATH_MSG_INFO(optprint << "  Address of m_nn: " << (void*)m_nn);
+    FCS_MSG_INFO(optprint << "  Address of m_nn: " << (void*)m_nn);
 }

--- a/source/Core/TFCSSimpleLWTNNHandler.cxx
+++ b/source/Core/TFCSSimpleLWTNNHandler.cxx
@@ -13,7 +13,7 @@
 TFCSSimpleLWTNNHandler::TFCSSimpleLWTNNHandler(const std::string& inputFile)
     : VNetworkLWTNN(inputFile)
 {
-  ATH_MSG_DEBUG("Setting up from inputFile.");
+  FCS_MSG_DEBUG("Setting up from inputFile.");
   setupPersistedVariables();
   TFCSSimpleLWTNNHandler::setupNet();
 };
@@ -24,7 +24,7 @@ TFCSSimpleLWTNNHandler::TFCSSimpleLWTNNHandler(
 {
   // Cannot take copy of lwt::LightweightNeuralNetwork
   // (copy constructor disabled)
-  ATH_MSG_DEBUG("Making new m_lwtnn_neural for copy of network.");
+  FCS_MSG_DEBUG("Making new m_lwtnn_neural for copy of network.");
   std::stringstream json_stream(m_json);
   const lwt::JSONConfig config = lwt::parse_json(json_stream);
   m_lwtnn_neural = std::make_unique<lwt::LightweightNeuralNetwork>(
@@ -35,20 +35,20 @@ TFCSSimpleLWTNNHandler::TFCSSimpleLWTNNHandler(
 void TFCSSimpleLWTNNHandler::setupNet()
 {
   // build the graph
-  ATH_MSG_DEBUG("Reading the m_json string stream into a neural network");
+  FCS_MSG_DEBUG("Reading the m_json string stream into a neural network");
   std::stringstream json_stream(m_json);
   const lwt::JSONConfig config = lwt::parse_json(json_stream);
   m_lwtnn_neural = std::make_unique<lwt::LightweightNeuralNetwork>(
       config.inputs, config.layers, config.outputs);
   // Get the output layers
-  ATH_MSG_DEBUG("Getting output layers for neural network");
+  FCS_MSG_DEBUG("Getting output layers for neural network");
   for (std::string name : config.outputs) {
-    ATH_MSG_VERBOSE("Found output layer called " << name);
+    FCS_MSG_VERBOSE("Found output layer called " << name);
     m_outputLayers.push_back(name);
   };
-  ATH_MSG_DEBUG("Removing prefix from stored layers.");
+  FCS_MSG_DEBUG("Removing prefix from stored layers.");
   removePrefixes(m_outputLayers);
-  ATH_MSG_DEBUG("Finished output nodes.");
+  FCS_MSG_DEBUG("Finished output nodes.");
 }
 
 std::vector<std::string> TFCSSimpleLWTNNHandler::getOutputLayers() const
@@ -61,11 +61,11 @@ std::vector<std::string> TFCSSimpleLWTNNHandler::getOutputLayers() const
 TFCSSimpleLWTNNHandler::NetworkOutputs TFCSSimpleLWTNNHandler::compute(
     TFCSSimpleLWTNNHandler::NetworkInputs const& inputs) const
 {
-  ATH_MSG_DEBUG("Running computation on LWTNN neural network");
-  ATH_MSG_DEBUG(VNetworkBase::representNetworkInputs(inputs, 20));
+  FCS_MSG_DEBUG("Running computation on LWTNN neural network");
+  FCS_MSG_DEBUG(VNetworkBase::representNetworkInputs(inputs, 20));
   // Flatten the map depth
   if (inputs.size() != 1) {
-    ATH_MSG_ERROR("The inputs have multiple elements."
+    FCS_MSG_ERROR("The inputs have multiple elements."
                   << " An LWTNN neural network can only handle one node.");
   };
   std::map<std::string, double> flat_inputs;
@@ -75,17 +75,17 @@ TFCSSimpleLWTNNHandler::NetworkOutputs TFCSSimpleLWTNNHandler::compute(
   // Now we have flattened, we can compute.
   NetworkOutputs outputs = m_lwtnn_neural->compute(flat_inputs);
   removePrefixes(outputs);
-  ATH_MSG_DEBUG(VNetworkBase::representNetworkOutputs(outputs, 20));
-  ATH_MSG_DEBUG("Computation on LWTNN neural network done, returning");
+  FCS_MSG_DEBUG(VNetworkBase::representNetworkOutputs(outputs, 20));
+  FCS_MSG_DEBUG("Computation on LWTNN neural network done, returning");
   return outputs;
 };
 
 // Giving this it's own streamer to call setupNet
 void TFCSSimpleLWTNNHandler::Streamer(TBuffer& buf)
 {
-  ATH_MSG_DEBUG("In streamer of " << __FILE__);
+  FCS_MSG_DEBUG("In streamer of " << __FILE__);
   if (buf.IsReading()) {
-    ATH_MSG_DEBUG("Reading buffer in TFCSSimpleLWTNNHandler ");
+    FCS_MSG_DEBUG("Reading buffer in TFCSSimpleLWTNNHandler ");
     // Get the persisted variables filled in
     TFCSSimpleLWTNNHandler::Class()->ReadBuffer(buf, this);
     // Setup the net, creating the non persisted variables
@@ -98,9 +98,9 @@ void TFCSSimpleLWTNNHandler::Streamer(TBuffer& buf)
 #endif
   } else {
     if (!m_json.empty()) {
-      ATH_MSG_DEBUG("Writing buffer in TFCSSimpleLWTNNHandler ");
+      FCS_MSG_DEBUG("Writing buffer in TFCSSimpleLWTNNHandler ");
     } else {
-      ATH_MSG_WARNING(
+      FCS_MSG_WARNING(
           "Writing buffer in TFCSSimpleLWTNNHandler, but m_json is empty.");
     }
     // Persist variables

--- a/source/Core/TFCSSimulationState.cxx
+++ b/source/Core/TFCSSimulationState.cxx
@@ -37,16 +37,16 @@ void TFCSSimulationState::deposit(const long long cell_id, float E)
 
 void TFCSSimulationState::Print(Option_t*) const
 {
-  ATH_MSG_INFO("Ebin=" << m_Ebin << " E=" << E()
+  FCS_MSG_INFO("Ebin=" << m_Ebin << " E=" << E()
                        << " #cells=" << m_cells.size());
   for (int i = 0; i < m_E.size(); ++i)
     if (E(i) != 0) {
-      ATH_MSG_INFO("  E" << i << E(i) << " E" << i << "/E=" << Efrac(i));
+      FCS_MSG_INFO("  E" << i << E(i) << " E" << i << "/E=" << Efrac(i));
     }
   if (!m_AuxInfo.empty()) {
-    ATH_MSG_INFO("  AuxInfo has " << m_AuxInfo.size() << " elements");
+    FCS_MSG_INFO("  AuxInfo has " << m_AuxInfo.size() << " elements");
     for (const auto& a : m_AuxInfo) {
-      ATH_MSG_INFO("    " << a.first
+      FCS_MSG_INFO("    " << a.first
                           << " : "
                           // Don't print as char/bool.
                           // Accessing as a bool is likely to undefined

--- a/source/Core/TFCSTruthState.cxx
+++ b/source/Core/TFCSTruthState.cxx
@@ -25,7 +25,7 @@ TFCSTruthState::TFCSTruthState(
 
 void TFCSTruthState::Print(Option_t*) const
 {
-  ATH_MSG_INFO("PDGID=" << m_pdgid << " pT=" << Pt() << " eta=" << Eta()
+  FCS_MSG_INFO("PDGID=" << m_pdgid << " pT=" << Pt() << " eta=" << Eta()
                         << " phi=" << Phi() << " E=" << E()
                         << " Ekin_off=" << Ekin_off());
 }

--- a/source/Core/VNetworkBase.cxx
+++ b/source/Core/VNetworkBase.cxx
@@ -19,7 +19,7 @@ VNetworkBase::VNetworkBase()
 VNetworkBase::VNetworkBase(const std::string& inputFile)
     : m_inputFile(inputFile)
 {
-  ATH_MSG_DEBUG("Constructor called with inputFile");
+  FCS_MSG_DEBUG("Constructor called with inputFile");
 };
 
 // No setupPersistedVariables or setupNet here!
@@ -73,10 +73,10 @@ std::string VNetworkBase::representNetworkOutputs(
 void VNetworkBase::print(std::ostream& strm) const
 {
   if (m_inputFile.empty()) {
-    ATH_MSG_DEBUG("Making a network without a named inputFile");
+    FCS_MSG_DEBUG("Making a network without a named inputFile");
     strm << "Unknown network";
   } else {
-    ATH_MSG_DEBUG("Making a network with input file " << m_inputFile);
+    FCS_MSG_DEBUG("Making a network with input file " << m_inputFile);
     strm << m_inputFile;
   };
 };
@@ -84,7 +84,7 @@ void VNetworkBase::print(std::ostream& strm) const
 void VNetworkBase::writeNetToTTree(TFile& root_file,
                                    std::string const& tree_name)
 {
-  ATH_MSG_DEBUG("Making tree name " << tree_name);
+  FCS_MSG_DEBUG("Making tree name " << tree_name);
   root_file.cd();
   const std::string title = "onnxruntime saved network";
   TTree tree(tree_name.c_str(), title.c_str());
@@ -95,7 +95,7 @@ void VNetworkBase::writeNetToTTree(TFile& root_file,
 void VNetworkBase::writeNetToTTree(std::string const& root_name,
                                    std::string const& tree_name)
 {
-  ATH_MSG_DEBUG("Making or updating file name " << root_name);
+  FCS_MSG_DEBUG("Making or updating file name " << root_name);
   TFile root_file(root_name.c_str(), "UPDATE");
   this->writeNetToTTree(root_file, tree_name);
   root_file.Close();
@@ -106,7 +106,7 @@ bool VNetworkBase::isRootFile(std::string const& filename) const
   const std::string* to_check = &filename;
   if (filename.length() == 0) {
     to_check = &this->m_inputFile;
-    ATH_MSG_DEBUG("No file name given, so using m_inputFile, " << m_inputFile);
+    FCS_MSG_DEBUG("No file name given, so using m_inputFile, " << m_inputFile);
   };
   const std::string ending = ".root";
   const int ending_len = ending.length();

--- a/source/Core/VNetworkLWTNN.cxx
+++ b/source/Core/VNetworkLWTNN.cxx
@@ -29,12 +29,12 @@ VNetworkLWTNN::~VNetworkLWTNN() {};
 void VNetworkLWTNN::setupPersistedVariables()
 {
   if (this->isFile(m_inputFile)) {
-    ATH_MSG_DEBUG("Making an LWTNN network using a file on disk, "
+    FCS_MSG_DEBUG("Making an LWTNN network using a file on disk, "
                   << m_inputFile);
     m_printable_name = m_inputFile;
     fillJson();
   } else {
-    ATH_MSG_DEBUG("Making an LWTNN network using a json in memory, length "
+    FCS_MSG_DEBUG("Making an LWTNN network using a json in memory, length "
                   << m_inputFile.length());
     m_printable_name = "JSON from memory";
     m_json = m_inputFile;
@@ -53,23 +53,23 @@ void VNetworkLWTNN::writeNetToTTree(TTree& tree)
 
 void VNetworkLWTNN::fillJson(std::string const& tree_name)
 {
-  ATH_MSG_VERBOSE("Trying to fill the m_json variable");
+  FCS_MSG_VERBOSE("Trying to fill the m_json variable");
   if (this->isRootFile()) {
-    ATH_MSG_VERBOSE("Treating input file as a root file");
+    FCS_MSG_VERBOSE("Treating input file as a root file");
     TFile tfile(this->m_inputFile.c_str(), "READ");
     TTree* tree = (TTree*)tfile.Get(tree_name.c_str());
     std::string found = this->readStringFromTTree(*tree);
-    ATH_MSG_DEBUG("Read json from root file, length " << found.length());
+    FCS_MSG_DEBUG("Read json from root file, length " << found.length());
     m_json = found;
   } else {
-    ATH_MSG_VERBOSE("Treating input file as a text json file");
+    FCS_MSG_VERBOSE("Treating input file as a text json file");
     // The input file is read into a stringstream
     std::ifstream input(m_inputFile);
     std::ostringstream sstr;
     sstr << input.rdbuf();
     m_json = sstr.str();
     input.close();
-    ATH_MSG_DEBUG("Read json from text file");
+    FCS_MSG_DEBUG("Read json from text file");
   }
 }
 
@@ -91,13 +91,13 @@ void VNetworkLWTNN::writeStringToTTree(TTree& tree, std::string json_string)
 
 void VNetworkLWTNN::deleteAllButNet()
 {
-  ATH_MSG_DEBUG("Replacing m_inputFile with unknown");
+  FCS_MSG_DEBUG("Replacing m_inputFile with unknown");
   m_inputFile.assign("unknown");
   m_inputFile.shrink_to_fit();
-  ATH_MSG_DEBUG("Emptying the m_json string");
+  FCS_MSG_DEBUG("Emptying the m_json string");
   m_json.clear();
   m_json.shrink_to_fit();
-  ATH_MSG_VERBOSE("m_json now has capacity "
+  FCS_MSG_VERBOSE("m_json now has capacity "
                   << m_json.capacity() << ". m_inputFile now has capacity "
                   << m_inputFile.capacity()
                   << ". m_printable_name now has capacity "

--- a/source/Extrapolation/FastCaloSimCaloExtrapolation.cxx
+++ b/source/Extrapolation/FastCaloSimCaloExtrapolation.cxx
@@ -16,12 +16,12 @@
    -- DEBUG   if CONDITION is True
    -- WARNING if CONDITION is False
  */
-#define ATH_MSG_COND(MSG, CONDITION) \
+#define FCS_MSG_COND(MSG, CONDITION) \
   do { \
     if (CONDITION) { \
-      ATH_MSG_DEBUG(MSG); \
+      FCS_MSG_DEBUG(MSG); \
     } else { \
-      ATH_MSG_WARNING(MSG); \
+      FCS_MSG_WARNING(MSG); \
     } \
   } while (0)
 
@@ -35,14 +35,14 @@ void FastCaloSimCaloExtrapolation::extrapolate(
     const TFCSTruthState* truth,
     const std::vector<G4FieldTrack>& caloSteps) const
 {
-  ATH_MSG_DEBUG("[extrapolate] Initializing extrapolation to ID-Calo boundary");
+  FCS_MSG_DEBUG("[extrapolate] Initializing extrapolation to ID-Calo boundary");
   extrapolateToID(result, caloSteps, truth);
 
-  ATH_MSG_DEBUG(
+  FCS_MSG_DEBUG(
       "[extrapolate] Initializing extrapolation to calorimeter layers");
   extrapolateToLayers(result, caloSteps, truth);
 
-  ATH_MSG_DEBUG("[extrapolate] Extrapolation done");
+  FCS_MSG_DEBUG("[extrapolate] Extrapolation done");
 }
 
 void FastCaloSimCaloExtrapolation::extrapolateToID(
@@ -50,7 +50,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
     const std::vector<G4FieldTrack>& caloSteps,
     const TFCSTruthState* truth) const
 {
-  ATH_MSG_DEBUG("Start extrapolateToID()");
+  FCS_MSG_DEBUG("Start extrapolateToID()");
 
   // pT threshold of truth particles over which extrapolation failures will be
   // printed as warnings
@@ -73,7 +73,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
     double R = m_CaloBoundaryR.at(surfID);
     double Z = m_CaloBoundaryZ.at(surfID);
 
-    ATH_MSG_DEBUG("[ExtrapolateToID] Extrapolating to ID-Calo boundary with ID="
+    FCS_MSG_DEBUG("[ExtrapolateToID] Extrapolating to ID-Calo boundary with ID="
                   << surfID << " R=" << R << " Z=" << Z);
 
     // extrapolated position and momentum direction at IDCaloBoundary
@@ -86,26 +86,26 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
     double tolerance = 0.001;
 
     // test if z inside previous cylinder within some tolerance
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[ExtrapolateToID] Testing condition 1: hit z=" << extPos.z());
     if (surfID > 0
         && std::abs(extPos.z()) < m_CaloBoundaryZ.at(surfID - 1) + tolerance)
       continue;
-    ATH_MSG_DEBUG("[ExtrapolateToID] Passed condition 1.");
+    FCS_MSG_DEBUG("[ExtrapolateToID] Passed condition 1.");
 
     // test if r inside next cylinder within some tolerance
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[ExtrapolateToID] Testing condition 2: hit r=" << extPos.perp());
     if (surfID < m_CaloBoundaryR.size() - 1
         && extPos.perp() < m_CaloBoundaryR.at(surfID + 1) + tolerance)
       continue;
-    ATH_MSG_DEBUG("[ExtrapolateToID] Passed condition 2.");
+    FCS_MSG_DEBUG("[ExtrapolateToID] Passed condition 2.");
 
-    ATH_MSG_DEBUG("[ExtrapolateToID] Testing condition 3: hit magnitude="
+    FCS_MSG_DEBUG("[ExtrapolateToID] Testing condition 3: hit magnitude="
                   << extPos.mag());
     if (extPosDist >= 0 && extPos.mag() > extPosDist)
       continue;
-    ATH_MSG_DEBUG("[ExtrapolateToID] Passed condition 3.");
+    FCS_MSG_DEBUG("[ExtrapolateToID] Passed condition 3.");
 
     extPosDist = extPos.mag();
 
@@ -116,7 +116,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
     result.set_IDCaloBoundary_y(extPos.y());
     result.set_IDCaloBoundary_z(extPos.z());
 
-    ATH_MSG_DEBUG("[ExtrapolateToID] Setting IDCaloBoundary to eta="
+    FCS_MSG_DEBUG("[ExtrapolateToID] Setting IDCaloBoundary to eta="
                   << extPos.eta() << " phi=" << extPos.phi()
                   << " r=" << extPos.perp() << " x=" << extPos.x()
                   << " y=" << extPos.y() << " z=" << extPos.z());
@@ -132,7 +132,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
   }  // end of loop over surfaces
 
   if (result.IDCaloBoundary_eta() == -999)
-    ATH_MSG_COND(
+    FCS_MSG_COND(
         "[ExtrapolateToID] Failed extrapolation to ID-Calo boundary. "
         "\n[ExtrapolateToID] Particle with truth vertex at ("
             << truth->vertex().X() << "," << truth->vertex().Y() << ","
@@ -143,7 +143,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToID(
             << " E=" << truth->E() << " Ekin_off=" << truth->Ekin_off(),
         truth->Pt() < transverseMomWarningLimit);
 
-  ATH_MSG_DEBUG("[ExtrapolateToID] End extrapolateToID()");
+  FCS_MSG_DEBUG("[ExtrapolateToID] End extrapolateToID()");
 }
 
 void FastCaloSimCaloExtrapolation::extrapolateToLayers(
@@ -151,7 +151,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToLayers(
     const std::vector<G4FieldTrack>& caloSteps,
     const TFCSTruthState* truth) const
 {
-  ATH_MSG_DEBUG("[extrapolateToLayers] Start extrapolate");
+  FCS_MSG_DEBUG("[extrapolateToLayers] Start extrapolate");
 
   // pT threshold of truth particles over which extrapolation failures will be
   // printed as warnings
@@ -241,7 +241,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToLayers(
           result.set_eta(sample, subpos, extPos.eta());
           result.set_r(sample, subpos, extPos.perp());
         } else {
-          ATH_MSG_COND(
+          FCS_MSG_COND(
               " [extrapolateToLayers] Extrapolation to cylinder failed. Sample="
                   << sample << " subpos=" << subpos
                   << " eta=" << result.IDCaloBoundary_eta()
@@ -255,7 +255,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToLayers(
   }  // inside calo
 
   else
-    ATH_MSG_COND(
+    FCS_MSG_COND(
         "[extrapolateToLayers] Ups. Not inside calo. "
         "result.IDCaloBoundary_eta()="
             << result.IDCaloBoundary_eta()
@@ -268,7 +268,7 @@ void FastCaloSimCaloExtrapolation::extrapolateToLayers(
             << " E=" << truth->E() << " Ekin_off=" << truth->Ekin_off(),
         truth->Pt() < transverseMomWarningLimit);
 
-  ATH_MSG_DEBUG("[extrapolateToLayers] End extrapolateToLayers()");
+  FCS_MSG_DEBUG("[extrapolateToLayers] End extrapolateToLayers()");
 }
 
 bool FastCaloSimCaloExtrapolation::extrapolateToCylinder(
@@ -280,7 +280,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateToCylinder(
 {
   if (caloSteps.size() == 1) {
     Vector3D hitPos = caloSteps.at(0).GetPosition();
-    ATH_MSG_DEBUG("[extrapolateWithPCA(R="
+    FCS_MSG_DEBUG("[extrapolateWithPCA(R="
                   << cylR << ",Z=" << cylZ
                   << ")] Extrapolating single hit position to surface.");
     extPos = projectOnCylinder(cylR, cylZ, hitPos);
@@ -296,14 +296,14 @@ bool FastCaloSimCaloExtrapolation::extrapolateToCylinder(
       : extrapolateWithPCA(caloSteps, cylR, cylZ, extPos, momDir);
 
   if (foundHit) {
-    ATH_MSG_DEBUG("[extrapolateToCylinder(R="
+    FCS_MSG_DEBUG("[extrapolateToCylinder(R="
                   << cylR << ",Z=" << cylZ
                   << ")::END] Extrapolated to cylinder with R=" << cylR
                   << " and Z=" << cylZ << " at (" << extPos.x() << ","
                   << extPos.y() << "," << extPos.z() << ")");
   } else {
     // this is not expected to ever happen
-    ATH_MSG_DEBUG("(R=" << cylR << ", Z=" << cylZ
+    FCS_MSG_DEBUG("(R=" << cylR << ", Z=" << cylZ
                         << "::END) Extrapolation to cylinder surface failed!");
   }
 
@@ -317,7 +317,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithIntersection(
     Vector3D& extPos,
     Vector3D& momDir) const
 {
-  ATH_MSG_DEBUG("[extrapolateWithIntersection(R="
+  FCS_MSG_DEBUG("[extrapolateWithIntersection(R="
                 << cylR << ",Z=" << cylZ
                 << ")] Checking for cylinder intersections of line segments.");
 
@@ -331,7 +331,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithIntersection(
     Vector3D hitPos2 = caloSteps.at(hitID).GetPosition();
     Vector3D hitDir = hitPos2 - hitPos1;
 
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[extrapolateWithIntersection(R="
         << cylR << ",Z=" << cylZ << ")] Considering line segment between ("
         << hitPos1.x() << "," << hitPos1.y() << "," << hitPos1.z() << ") and ("
@@ -345,7 +345,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithIntersection(
       extPos = cylPosHit1 == ON ? hitPos1 : hitPos2;
       momDir = cylPosHit1 == ON ? caloSteps.at(hitID - 1).GetMomentumDir()
                                 : caloSteps.at(hitID).GetMomentumDir();
-      ATH_MSG_DEBUG("[extrapolateWithIntersection(R="
+      FCS_MSG_DEBUG("[extrapolateWithIntersection(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Hit position already on cylinder surface.");
       return true;
@@ -423,7 +423,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithIntersection(
         extPos = selectedIntersection;
         return true;
       }
-      ATH_MSG_DEBUG("[extrapolateWithIntersection(R="
+      FCS_MSG_DEBUG("[extrapolateWithIntersection(R="
                     << cylR << ",Z=" << cylZ << ")] Extrapolated position at ("
                     << selectedIntersection.x() << ","
                     << selectedIntersection.y() << ","
@@ -442,7 +442,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithPCA(
     Vector3D& momDir) const
 {
   bool foundHit = false;
-  ATH_MSG_DEBUG("[extrapolateWithPCA(R="
+  FCS_MSG_DEBUG("[extrapolateWithPCA(R="
                 << cylR << ",Z=" << cylZ
                 << ")] No forward intersections with cylinder surface. "
                    "Extrapolating to closest point on surface.");
@@ -453,7 +453,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithPCA(
     Vector3D hitPos1 = caloSteps.at(hitID - 1).GetPosition();
     Vector3D hitPos2 = caloSteps.at(hitID).GetPosition();
 
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[extrapolateWithPCA(R="
         << cylR << ",Z=" << cylZ << ")] Considering line segment between ("
         << hitPos1.x() << "," << hitPos1.y() << "," << hitPos1.z() << ") and ("
@@ -467,7 +467,7 @@ bool FastCaloSimCaloExtrapolation::extrapolateWithPCA(
     Vector3D cylinderSurfacePCA = projectOnCylinder(cylR, cylZ, PCA);
     double tmpMinDistToSurface = (PCA - cylinderSurfacePCA).mag();
 
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[extrapolateWithPCA(R="
         << cylR << ",Z=" << cylZ << ")] Extrapolated line segment to ("
         << cylinderSurfacePCA.x() << "," << cylinderSurfacePCA.y() << ","
@@ -624,7 +624,7 @@ void FastCaloSimCaloExtrapolation::getIterativePCA(float cylR,
                                                    Vector3D& BoundB,
                                                    Vector3D& PCA) const
 {
-  ATH_MSG_DEBUG("[getIterativePCA] Finding PCA iteratively.");
+  FCS_MSG_DEBUG("[getIterativePCA] Finding PCA iteratively.");
 
   Vector3D boundDir = BoundB - BoundA;
   double distBounds = boundDir.mag();
@@ -718,13 +718,13 @@ auto FastCaloSimCaloExtrapolation::circleLineIntersection2D(
   det = B * B - 4 * A * C;
 
   if (A <= 0.0000001 || det < 0) {
-    ATH_MSG_DEBUG("[circleLineIntersection2D] No intersections.");
+    FCS_MSG_DEBUG("[circleLineIntersection2D] No intersections.");
     return 0;
   } else if (std::abs(det) < 0.00001) {
     // one solution, tangential case.
     t = -B / (2 * A);
     intersectA = {pointA.x() + t * dx, pointA.y() + t * dy, pointA.z()};
-    ATH_MSG_DEBUG("[circleLineIntersection2D] One intersection at ("
+    FCS_MSG_DEBUG("[circleLineIntersection2D] One intersection at ("
                   << intersectA.x() << "," << intersectA.y() << ","
                   << intersectA.z() << ").");
     return 1;
@@ -734,7 +734,7 @@ auto FastCaloSimCaloExtrapolation::circleLineIntersection2D(
     intersectA = {pointA.x() + t * dx, pointA.y() + t * dy, pointA.z()};
     t = (-B - std::sqrt(det)) / (2 * A);
     intersectB = {pointA.x() + t * dx, pointA.y() + t * dy, pointB.z()};
-    ATH_MSG_DEBUG("[circleLineIntersection2D] Two intersections at ("
+    FCS_MSG_DEBUG("[circleLineIntersection2D] Two intersections at ("
                   << intersectA.x() << "," << intersectA.y() << ","
                   << intersectA.z() << ") and at (" << intersectB.x() << ","
                   << intersectB.y() << "," << intersectB.z() << ").");
@@ -793,7 +793,7 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
   unsigned int nCoverIntersections = cylinderLineIntersection(
       cylR, cylZ, hitPos1, hitPos2, intersections.first, intersections.second);
   if (nCoverIntersections == 2) {
-    ATH_MSG_DEBUG(
+    FCS_MSG_DEBUG(
         "[getCylinderIntersections(R="
         << cylR << ",Z=" << cylZ
         << ")] Found two cylinder intersections through cylinder cover.");
@@ -813,7 +813,7 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
       // case take the endcap intersection which is further away from the
       // cylinder cover intersection to prevent taking the same intersection
       // twice
-      ATH_MSG_DEBUG(
+      FCS_MSG_DEBUG(
           "[getCylinderIntersections(R="
           << cylR << ",Z=" << cylZ
           << ")] Found intersection through cylinder cover and both endcaps. "
@@ -825,14 +825,14 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
           : negativeEndcapIntersection;
       intersections.number = 2;
     } else if (IsPositiveEndcapIntersection) {
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found intersection through cylinder cover and "
                        "positive endcap.");
       intersections.second = positiveEndcapIntersection;
       intersections.number = 2;
     } else if (IsNegativeEndcapIntersection) {
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found intersection through cylinder cover and "
                        "negative endcap.");
@@ -840,7 +840,7 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
       intersections.number = 2;
     } else {
       // line is tangential to cylinder cover
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found single intersection through cylinder cover.");
       intersections.number = 1;
@@ -855,7 +855,7 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
         cylR, cylZ, false, hitPos1, hitPos2, negativeEndcapIntersection);
 
     if (IsPositiveEndcapIntersection && IsNegativeEndcapIntersection) {
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found intersections through both endcaps.");
       intersections.first = positiveEndcapIntersection;
@@ -863,7 +863,7 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
       intersections.number = 2;
     } else if (IsPositiveEndcapIntersection) {
       // don't expect this to ever happen
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found single intersection through positive endcap. "
                        "This should not happen.");
@@ -871,14 +871,14 @@ CylinderIntersections FastCaloSimCaloExtrapolation::getCylinderIntersections(
       intersections.number = 1;
     } else if (IsNegativeEndcapIntersection) {
       // don't expect this to ever happen
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found single intersection through negative endcap. "
                        "This should not happen.");
       intersections.first = negativeEndcapIntersection;
       intersections.number = 1;
     } else {
-      ATH_MSG_DEBUG("[getCylinderIntersections(R="
+      FCS_MSG_DEBUG("[getCylinderIntersections(R="
                     << cylR << ",Z=" << cylZ
                     << ")] Found no cylinder intersections.");
       // no intersections at all
@@ -940,7 +940,7 @@ int FastCaloSimCaloExtrapolation::cylinderLineIntersection(
   double d2 = projPointA.dot(projPointA) - t * t * projDiffNorm2;
 
   if (d2 < 0) {
-    ATH_MSG_COND("[cylinderLineIntersection] Got negative distance (d2="
+    FCS_MSG_COND("[cylinderLineIntersection] Got negative distance (d2="
                      << d2 << "). Forcing to 0.",
                  d2 > -0.001);
     d2 = 0;
@@ -1016,7 +1016,7 @@ int FastCaloSimCaloExtrapolation::whichIntersection(
     /* CASE A: one hit position inside and one outside of the cylinder (travel
     through surface), one intersection is on cylinder, take intersection closest
     to line segment */
-    ATH_MSG_DEBUG("[whichIntersection] Travel through surface.");
+    FCS_MSG_DEBUG("[whichIntersection] Travel through surface.");
     return getPointLineSegmentDistance(intersectionA, hitPos1, hitPos2)
         > getPointLineSegmentDistance(intersectionB, hitPos1, hitPos2);
   } else if (cylPosHit1 == INSIDE && cylPosHit2 == INSIDE) {
@@ -1025,7 +1025,7 @@ int FastCaloSimCaloExtrapolation::whichIntersection(
     Vector3D dirA = intersectionA - hitPos2;
     Vector3D dirB = intersectionB - hitPos2;
     Vector3D hitDir = hitPos2 - hitPos1;
-    ATH_MSG_DEBUG("[whichIntersection] Both hit positions inside.");
+    FCS_MSG_DEBUG("[whichIntersection] Both hit positions inside.");
     return dirA.dot(hitDir) < dirB.dot(hitDir);
   } else {
     // /* CASE C: both hit position outside and the intersections lay on the
@@ -1035,7 +1035,7 @@ int FastCaloSimCaloExtrapolation::whichIntersection(
     // positions */
     double distHitPosIntersectA = (hitPos2 - intersectionA).mag();
     double distHitPosIntersectB = (hitPos2 - intersectionB).mag();
-    ATH_MSG_DEBUG("[whichIntersection] Both hit positions outside.");
+    FCS_MSG_DEBUG("[whichIntersection] Both hit positions outside.");
     return distHitPosIntersectA > distHitPosIntersectB;
   }
 }

--- a/test/TestConfig/AtlasSimTestsConfig.h
+++ b/test/TestConfig/AtlasSimTestsConfig.h
@@ -15,7 +15,8 @@ class AtlasSimTestConfig : public ::testing::Environment
 {
 public:
   // Extrapolation debug level
-  inline static const MSG::Level EXTRAPOLATION_MSG_LEVEL = MSG::Level::INFO;
+  inline static const FCS_MSG::Level EXTRAPOLATION_FCS_MSG_LEVEL =
+      FCS_MSG::Level::INFO;
 
   // The list of events (event = particle container) to be simulated
   inline static const std::vector<TestHelpers::Event> EVENTS = []()

--- a/test/TestConfig/AtlasTransportTestsConfig.h
+++ b/test/TestConfig/AtlasTransportTestsConfig.h
@@ -18,7 +18,8 @@ public:
   inline static const bool ZOOM_IN = false;
 
   // Extrapolation debug level
-  inline static const MSG::Level EXTRAPOLATION_MSG_LEVEL = MSG::Level::INFO;
+  inline static const FCS_MSG::Level EXTRAPOLATION_FCS_MSG_LEVEL =
+      FCS_MSG::Level::INFO;
 
   // The output directory for the test
   inline static const std::string OUTPUT_DIR = "output/";

--- a/test/include/BasicExtrapolTests.h
+++ b/test/include/BasicExtrapolTests.h
@@ -20,7 +20,7 @@ protected:
     // Set the geometry of the extrapolator
     extrapolator.set_geometry(AtlasGeoTests::geo);
     // Set the verbosity level
-    extrapolator.setLevel(MSG::Level::INFO);
+    extrapolator.setLevel(FCS_MSG::Level::INFO);
   }
 
   // Per-test-suite tear-down.

--- a/test/source/AtlasSimTests.cxx
+++ b/test/source/AtlasSimTests.cxx
@@ -43,7 +43,7 @@ TEST_P(AtlasSimTests, AtlasSimulation)
 
   // Set the extrapolation tool
   BasicExtrapolTests::extrapolator.setLevel(
-      AtlasSimTestConfig::EXTRAPOLATION_MSG_LEVEL);
+      AtlasSimTestConfig::EXTRAPOLATION_FCS_MSG_LEVEL);
   model->setExtrapolationTool(BasicExtrapolTests::extrapolator);
 
   // Activate the simulation for this test
@@ -58,7 +58,7 @@ TEST_P(AtlasSimTests, AtlasSimulation)
   // Set up the geometry
   param->set_geometry(AtlasGeoTests::geo);
   // Set logging level
-  param->setLevel(MSG::Level::VERBOSE);
+  param->setLevel(FCS_MSG::Level::VERBOSE);
 
   // Set the param in the model
   model->setParametrization(param);

--- a/test/source/AtlasTransportTests.cxx
+++ b/test/source/AtlasTransportTests.cxx
@@ -43,7 +43,7 @@ TEST_P(AtlasTransportTests, AtlasTransport)
 
   // Set the extrapolation tool
   BasicExtrapolTests::extrapolator.setLevel(
-      AtlasTransportTestConfig::EXTRAPOLATION_MSG_LEVEL);
+      AtlasTransportTestConfig::EXTRAPOLATION_FCS_MSG_LEVEL);
   model->setExtrapolationTool(BasicExtrapolTests::extrapolator);
 
   // Start a run

--- a/test/source/BasicSimTests.cxx
+++ b/test/source/BasicSimTests.cxx
@@ -33,7 +33,7 @@ TEST_F(BasicSimTests, DoDummySimulation)
   // Set up the geometry
   param->set_geometry(AtlasGeoTests::geo);
   // Set logging level
-  param->setLevel(MSG::Level::VERBOSE);
+  param->setLevel(FCS_MSG::Level::VERBOSE);
 
   // Set up a random engine
   std::unique_ptr<CLHEP::RanluxEngine> rnd_engine =

--- a/test/source/TruthStateTests.cxx
+++ b/test/source/TruthStateTests.cxx
@@ -49,7 +49,7 @@ TEST(TFCSTruthStateTest, EkinComputation)
   EXPECT_NEAR(ts.Ekin(), expectedEkin, 1e-6);
 }
 
-// Print functionality (mocking ATH_MSG_INFO)
+// Print functionality (mocking FCS_MSG_INFO)
 TEST(TFCSTruthStateTest, Print)
 {
   TFCSTruthState ts(1.0, 0, 0, 1.0, 11);


### PR DESCRIPTION
To comply with messaging in Athena, our messaging currently relies on preprocessor macros. As those are identical with what is used in some Athena classes, we'll rename the `ATH_MSG` to `FCS_MSG` for now to avoid any interference. Eventually, we should re-design the messaging to not use macros at all. 