### PR TITLE
Fix bitfield decoder offset treatment

### DIFF
--- a/key4hep/BitFieldDecoder/BitFieldDecoder/decoder.py
+++ b/key4hep/BitFieldDecoder/BitFieldDecoder/decoder.py
@@ -73,6 +73,8 @@ class Decoder:
                 name, offset, width = parts[0], int(parts[1]), int(parts[2])
             else:
                 raise ValueError(f"Invalid field description: {field_desc}")
+            if name in self.fields:
+                raise ValueError(f"Duplicate field name detected: '{name}'")
             self.fields[name] = Field(name, offset, width)
             current_offset = max(current_offset, offset + abs(width))
 

--- a/key4hep/BitFieldDecoder/BitFieldDecoder/decoder.py
+++ b/key4hep/BitFieldDecoder/BitFieldDecoder/decoder.py
@@ -1,90 +1,95 @@
 class Field:
     """
-    Represents a bit field in a structured data format.
+    Represents a single bit field in a structured binary format.
 
     Attributes:
         name (str): The name of the field.
-        width (int): The width (number of bits) of the field.
         offset (int): The starting bit position of the field.
-        is_signed (bool): Whether the field represents a signed integer.
-        mask (int): The bitmask used to isolate the field within a value.
+        width (int): The number of bits in the field (absolute value).
+        is_signed (bool): Whether the field is signed (negative width indicates signed).
+        mask (int): The bitmask used to extract the field value.
         min_val (int): The minimum value the field can hold (for signed fields).
         max_val (int): The maximum value the field can hold.
     """
 
-    def __init__(self, name, width, offset, is_signed):
+    def __init__(self, name, offset, width):
         """
         Initializes a Field object.
 
         Args:
             name (str): The name of the field.
-            width (int): The number of bits in the field.
             offset (int): The starting bit position of the field.
-            is_signed (bool): Whether the field represents a signed integer.
+            width (int): The number of bits in the field. Negative indicates signed.
+
+        Raises:
+            ValueError: If the width is zero.
         """
-        if width <= 0:
-            raise ValueError("Field width must be a positive integer.")
-        if offset < 0:
-            raise ValueError("Field offset must be a non-negative integer.")
-
+        if width == 0:
+            raise ValueError("Field width cannot be zero.")
         self.name = name
-        self.width = width
         self.offset = offset
-        self.is_signed = is_signed
-        self.mask = ((1 << width) - 1) << offset
-
-        if is_signed:
-            self.min_val = -(1 << (width - 1))
-            self.max_val = (1 << (width - 1)) - 1
-        else:
-            self.min_val = 0
-            self.max_val = (1 << width) - 1
+        self.width = abs(width)
+        self.is_signed = width < 0
+        self.mask = ((1 << self.width) - 1) << self.offset
+        self.min_val = -(1 << (self.width - 1)) if self.is_signed else 0
+        self.max_val = (
+            (1 << (self.width - 1)) - 1 if self.is_signed else (1 << self.width) - 1
+        )
 
 
 class Decoder:
     """
-    Decodes values based on a structured field description.
+    Decodes a structured binary format using a schema of fields.
 
     Attributes:
-        fields (dict): A dictionary of field names to Field objects.
+        fields (dict): A dictionary mapping field names to Field objects.
         current_value (int): The current value being decoded.
     """
 
     def __init__(self, description):
         """
-        Initializes a Decoder object with a description of fields.
+        Initializes a Decoder object with a schema description.
 
         Args:
             description (str): A comma-separated string describing the fields.
-                Each field is described as "name:width" where width can be
-                positive (unsigned) or negative (signed).
-                Example: "field1:8,field2:-16" (8-bit unsigned and 16-bit signed).
+                Each field can be:
+                - "name:width" → Width with cumulative implicit offsets.
+                - "name:offset:width" → Explicit offset and width.
+                Example: "system:8,barrel:8:3,module:11:4,layer:15:6,x:32:-16,y:-16"
+
+        Raises:
+            ValueError: If a field description is invalid.
         """
         self.fields = {}
-        self.current_value = 0
-        offset = 0
+        current_offset = 0
 
         for field_desc in description.split(","):
-            try:
-                name, width = field_desc.split(":")
-                width = int(width)
-            except ValueError:
+            parts = field_desc.split(":")
+            if len(parts) == 2:  # "name:width"
+                name, width = parts[0], int(parts[1])
+                offset = current_offset
+                current_offset += abs(width)
+            elif len(parts) == 3:  # "name:offset:width"
+                name, offset, width = parts[0], int(parts[1]), int(parts[2])
+            else:
                 raise ValueError(f"Invalid field description: {field_desc}")
+            self.fields[name] = Field(name, offset, width)
+            current_offset = max(current_offset, offset + abs(width))
 
-            is_signed = width < 0
-            width = abs(width)
-            self.fields[name] = Field(name, width, offset, is_signed)
-            offset += width
+        self._print_field_table()
 
-        # Print table of all fields and field properties
+    def _print_field_table(self):
+        """
+        Prints a table of all initialized fields, showing their properties.
+        """
         print("\nDecoder initialized with the following fields:\n")
         print(
-            f"{'Field':<10} {'Width (bits)':<15} {'Signed':<10} {'Min Value':<15} {'Max Value':<15}"
+            f"{'Field':<10} {'Offset (bits)':<15} {'Width (bits)':<15} {'Signed':<10} {'Min Value':<15} {'Max Value':<15}"
         )
-        print("-" * 65)
+        print("-" * 80)
         for field in self.fields.values():
             print(
-                f"{field.name:<10} {field.width:<15} {'Yes' if field.is_signed else 'No':<10} {field.min_val:<15} {field.max_val:<15}"
+                f"{field.name:<10} {field.offset:<15} {field.width:<15} {'Yes' if field.is_signed else 'No':<10} {field.min_val:<15} {field.max_val:<15}"
             )
 
     def set_value(self, value):
@@ -92,7 +97,10 @@ class Decoder:
         Sets the current value to be decoded.
 
         Args:
-            value (int): The value to be decoded.
+            value (int): The value to decode.
+
+        Raises:
+            TypeError: If the value is not an integer.
         """
         if not isinstance(value, int):
             raise TypeError("Value must be an integer.")
@@ -104,8 +112,7 @@ class Decoder:
 
         Args:
             name (str): The name of the field to extract.
-            value (int, optional): The value to decode. If not provided,
-                the current_value is used.
+            value (int, optional): The value to decode. Defaults to the current value.
 
         Returns:
             int: The decoded value of the specified field.
@@ -116,22 +123,21 @@ class Decoder:
         """
         if name not in self.fields:
             raise KeyError(f"Field '{name}' does not exist.")
-
         if value is not None and not isinstance(value, int):
             raise TypeError("Provided value must be an integer.")
 
         target_value = self.current_value if value is None else value
         field = self.fields[name]
+
+        # Extract the raw bits
         result = (target_value & field.mask) >> field.offset
 
         # Handle signed values
         if field.is_signed and (result & (1 << (field.width - 1))):
             result -= 1 << field.width
-
         # Verify result is within field bounds
         if not (field.min_val <= result <= field.max_val):
             raise ValueError(
                 f"Decoded value {result} exceeds field bounds [{field.min_val}, {field.max_val}]"
             )
-
         return result

--- a/test/python/bitfield_decoder_tests.py
+++ b/test/python/bitfield_decoder_tests.py
@@ -6,97 +6,67 @@ class TestBitFieldDecoder(unittest.TestCase):
     """
     Unit tests for the BitFieldDecoder module.
 
-    The BitFieldDecoder extracts specific fields from integer values based on a given schema.
-    The schema defines how bits are divided into named fields. For example:
-    - `sys:2,name:2,type:4` divides a binary number into 3 fields:
-        - `sys`: 2 least significant bits (LSBs)
-        - `name`: 2 bits above `sys`
-        - `type`: 4 most significant bits (MSBs)
-
-    The tests ensure that the decoder:
-    1. Correctly extracts field values based on the schema for given integers.
-    2. Works with complex schemas and multiple fields, as in the `ecal` example.
+    This suite verifies the functionality of the Decoder class for various schemas
+    and values, ensuring correct extraction of bit fields from integer values.
     """
+
+    def assert_decoder(self, schema, test_cases):
+        """
+        Helper function to test a Decoder against multiple cases.
+
+        Args:
+            schema (str): The schema to use for the decoder.
+            test_cases (list[tuple[int, dict[str, int]]]):
+                A list of tuples where each tuple contains:
+                - The integer value to decode.
+                - A dictionary mapping field names to expected values.
+        """
+        dec = decoder.Decoder(schema)
+
+        for value, expected_fields in test_cases:
+            with self.subTest(value=value):
+                dec.set_value(value)
+                for field, expected_value in expected_fields.items():
+                    actual = dec.value(field)
+                    self.assertEqual(
+                        actual,
+                        expected_value,
+                        f"Mismatch for field '{field}' with value {value}: got {actual}, expected {expected_value}",
+                    )
 
     def test_basic_decoder_values(self):
         """
-        Test the basic functionality of the decoder with a simple schema.
+        Test basic decoding functionality with a simple schema.
 
         Schema: "sys:2,name:2,type:4"
-        - `sys`:  Unsigned, width of 2 bits, can hold values from 0 to 3
-        - `name`: Unsigned, width of 2 bits, can hold values from 0 to 3
-        - `type`: Unsigned, width of 4 bits, can hold values from 0 to 15
-
-        Verifies that the `value` method correctly decodes these fields for
-        several input integers.
         """
-        # Initialize the basic decoder
-        dec = decoder.Decoder("sys:2,name:2,type:4")
-
-        # Define test cases with input values and expected results
         test_cases = [
-            (5, {"type": 0, "name": 1, "sys": 1}),  # Binary: 0000 0101
-            (7, {"type": 0, "name": 1, "sys": 3}),  # Binary: 0000 0111
-            (15, {"type": 0, "name": 3, "sys": 3}),  # Binary: 0000 1111
-            (21, {"type": 1, "name": 1, "sys": 1}),  # Binary: 0001 0101
+            (5, {"type": 0, "name": 1, "sys": 1}),
+            (7, {"type": 0, "name": 1, "sys": 3}),
+            (15, {"type": 0, "name": 3, "sys": 3}),
+            (21, {"type": 1, "name": 1, "sys": 1}),
         ]
-
-        # Run the test cases
-        for value, expected in test_cases:
-            with self.subTest(value=value):
-                self.assertEqual(
-                    dec.value("type", value),
-                    expected["type"],
-                    f"Type mismatch for value {value}",
-                )
-                self.assertEqual(
-                    dec.value("name", value),
-                    expected["name"],
-                    f"Name mismatch for value {value}",
-                )
-                self.assertEqual(
-                    dec.value("sys", value),
-                    expected["sys"],
-                    f"Sys mismatch for value {value}",
-                )
+        self.assert_decoder("sys:2,name:2,type:4", test_cases)
 
     def test_negative_fields(self):
         """
-        Test the decoder with negative field values.
+        Test decoding signed fields with negative widths.
 
         Schema: "x:-16,y:-16"
-        - `x`: Signed, width of 16 bits, can hold values from -32768 to 32767
-        - `y`: Signed, width of 16 bits, can hold values from -32768 to 32767
         """
-
-        dec = decoder.Decoder("x:-16,y:-16")
-
         test_cases = [
-            (4294901760, {"x": 0, "y": -1}),  # 0000 0000 0000 0000 1111 1111 1111 1111
-            (65535, {"x": -1, "y": 0}),  # 1111 1111 1111 1111 0000 0000 0000 0000
-            (0, {"x": 0, "y": 0}),  # 0000 0000 0000 0000 0000 0000 0000 0000
-            (4294967295, {"x": -1, "y": -1}),  # 1111 1111 1111 1111 1111 1111 1111 1111
+            (4294901760, {"x": 0, "y": -1}),
+            (65535, {"x": -1, "y": 0}),
+            (0, {"x": 0, "y": 0}),
+            (4294967295, {"x": -1, "y": -1}),
         ]
-        for value, expected in test_cases:
-            with self.subTest(value=value):
-                self.assertEqual(
-                    dec.value("x", value),
-                    expected["x"],
-                    f"X mismatch for value {value}",
-                )
-                self.assertEqual(
-                    dec.value("y", value),
-                    expected["y"],
-                    f"Y mismatch for value {value}",
-                )
+        self.assert_decoder("x:-16,y:-16", test_cases)
 
     def test_mixed_fields(self):
         """
-        Test the decoder with mixed field values.
+        Test decoding with mixed signed and unsigned fields.
 
         Schema: "x:16,y:-16"
-        - `x`: Unsigned, width of 16 bits, can hold values from 0 to 65536
-        - `y`: Signed, width of 16 bits, can hold values from -32768 to 32767
         """
         test_cases = [
             (24947260, {"x": 43580, "y": 380}),
@@ -104,70 +74,127 @@ class TestBitFieldDecoder(unittest.TestCase):
             (2682840153, {"x": 58457, "y": -24600}),
             (2860302816, {"x": 49632, "y": -21892}),
         ]
+        self.assert_decoder("x:16,y:-16", test_cases)
 
-        dec = decoder.Decoder("x:16,y:-16")
+    def test_offset_fields(self):
+        """
+        Test decoding with explicit offsets and signed/unsigned mixed fields.
 
-        for value, expected in test_cases:
-            with self.subTest(value=value):
-                self.assertEqual(
-                    dec.value("x", value),
-                    expected["x"],
-                    f"X mismatch for value {value}",
-                )
-                self.assertEqual(
-                    dec.value("y", value),
-                    expected["y"],
-                    f"Y mismatch for value {value}",
-                )
+        Schema: "system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16"
+        """
+        test_cases = [
+            (
+                15199511311933456,
+                {
+                    "system": 16,
+                    "barrel": 0,
+                    "module": 12,
+                    "layer": 3,
+                    "slice": 4,
+                    "x": -32,
+                    "y": 53,
+                },
+            ),
+            (
+                6192479558754323,
+                {
+                    "system": 19,
+                    "barrel": 0,
+                    "module": 12,
+                    "layer": 1,
+                    "slice": 3,
+                    "x": 7,
+                    "y": 22,
+                },
+            ),
+            (
+                3659187588530195,
+                {
+                    "system": 19,
+                    "barrel": 0,
+                    "module": 0,
+                    "layer": 3,
+                    "slice": 3,
+                    "x": 3,
+                    "y": 13,
+                },
+            ),
+        ]
+        self.assert_decoder(
+            "system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16", test_cases
+        )
 
     def test_complex_decoder_values(self):
         """
-        Test the decoder with a more complex schema
+        Test decoding with a complex schema and multiple fields.
 
         Schema: "system:4,cryo:1,module:11,type:3,subtype:3,cell:6,eta:9"
-        - `system`: 4 bits (most significant)
-        - `cryo`: 1 bit
-        - `module`: 11 bits
-        - `type`: 3 bits
-        - `subtype`: 3 bits
-        - `cell`: 6 bits
-        - `eta`: 9 bits (least significant)
-
-        Test data maps integers to expected field values.
-
-        Verifies that the `set_value` and `value` methods correctly decode
-        the fields for each input value.
         """
-        # Fields and schema for the ecal decoder
-        fields = ("system", "cryo", "module", "type", "subtype", "cell", "eta")
-        ecal = decoder.Decoder(
-            "system:4,cryo:1,module:11,type:3,subtype:3,cell:6,eta:9"
+        test_cases = [
+            (
+                36280732133,
+                {
+                    "system": 5,
+                    "cryo": 0,
+                    "module": 79,
+                    "type": 0,
+                    "subtype": 0,
+                    "cell": 10,
+                    "eta": 135,
+                },
+            ),
+            (
+                35987131109,
+                {
+                    "system": 5,
+                    "cryo": 0,
+                    "module": 87,
+                    "type": 0,
+                    "subtype": 0,
+                    "cell": 4,
+                    "eta": 134,
+                },
+            ),
+            (
+                37358668421,
+                {
+                    "system": 5,
+                    "cryo": 0,
+                    "module": 84,
+                    "type": 0,
+                    "subtype": 0,
+                    "cell": 11,
+                    "eta": 139,
+                },
+            ),
+            (
+                36263955141,
+                {
+                    "system": 5,
+                    "cryo": 0,
+                    "module": 86,
+                    "type": 0,
+                    "subtype": 0,
+                    "cell": 6,
+                    "eta": 135,
+                },
+            ),
+            (
+                35995519653,
+                {
+                    "system": 5,
+                    "cryo": 0,
+                    "module": 85,
+                    "type": 0,
+                    "subtype": 0,
+                    "cell": 6,
+                    "eta": 134,
+                },
+            ),
+        ]
+        self.assert_decoder(
+            "system:4,cryo:1,module:11,type:3,subtype:3,cell:6,eta:9", test_cases
         )
-
-        # Define test cases with input values and expected field results
-        vals = {
-            36280732133: [5, 0, 79, 0, 0, 10, 135],
-            35987131109: [5, 0, 87, 0, 0, 4, 134],
-            37358668421: [5, 0, 84, 0, 0, 11, 139],
-            36263955141: [5, 0, 86, 0, 0, 6, 135],
-            35995519653: [5, 0, 85, 0, 0, 6, 134],
-        }
-
-        # Run the test cases
-        for val, expected_values in vals.items():
-            with self.subTest(value=val):
-                # Set the current value to the decoder
-                ecal.set_value(val)
-
-                # Check each field
-                for ifield, field in enumerate(fields):
-                    actual = ecal.value(field)
-                    expected = expected_values[ifield]
-                    self.assertEqual(
-                        actual,
-                        expected,
-                        f"Mismatch for field '{field}' with value {val}: got {actual}, expected {expected}",
-                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request fixed the treatment of bitfield offets in the key4hep bitfield decoder first introduced in https://github.com/fcs-proj/FastCaloSim/pull/51. Previously only fields with `name:width`, now we also support fields with `name:offset:width`. This is necessar to support the ODD calo schema

`system:8,barrel:3,module:4,layer:6,slice:5,x:32:-16,y:-16`

Unit tests have been added as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `Field` and `Decoder` classes for improved bit field representation and flexibility in field descriptions.
	- Introduced a new test method for decoding with explicit offsets and mixed signed/unsigned fields.

- **Bug Fixes**
	- Improved error handling in the `set_value` method to ensure only integers are accepted.

- **Documentation**
	- Clarified documentation for the `value` method and revised class docstrings in tests for better understanding.

- **Tests**
	- Refactored unit tests for better organization and maintainability, introducing a helper method to streamline assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->