### PR TITLE
Add std::vector of core classes to LinkDef

### DIFF
--- a/include/FastCaloSim/LinkDef.h
+++ b/include/FastCaloSim/LinkDef.h
@@ -638,5 +638,10 @@
 #pragma link C++ class TFCSTruthState + ;
 #pragma link C++ class TFCSExtrapolationState + ;
 #pragma link C++ class TFCSSimulationState + ;
+
+#pragma link C++ class std::vector<TFCSTruthState> + ;
+#pragma link C++ class std::vector<TFCSExtrapolationState> + ;
+#pragma link C++ class std::vector<TFCSSimulationState> + ;
+
 #endif
 // clang-format on


### PR DESCRIPTION
This PR adds pragma linkage directives for TFCSTruthState, TFCSExtrapolationState, and TFCSSimulationState, such that we can save std::vectors of these objects into ROOT files, needed for https://github.com/fcs-proj/DDFastCaloSim implementation of the parametrization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced internal support for managing collections of simulation state objects to streamline simulation workflows.
  - Upgraded the system to handle grouped simulation data more efficiently, contributing to improved performance and reliability.
  - Overall, these updates help ensure a smoother and more robust simulation environment for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->