### PR TITLE
Inherit github actions secret

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -16,6 +16,7 @@ jobs:
     needs: [docker-check]
     if: ${{ needs.docker-check.outputs.docker_changed == 'true' }}
     uses: ./.github/workflows/docker-build.yml
+    secrets: inherit
 
   # Run the main tests
   test:
@@ -25,3 +26,4 @@ jobs:
     uses: ./.github/workflows/pipeline.yml
     with:
       container_tag: ${{ needs.docker-check.outputs.docker_changed == 'true' && format('pr-{0}', github.event.pull_request.number) || 'latest' }}
+    secrets: inherit

--- a/docker/alma9/Dockerfile
+++ b/docker/alma9/Dockerfile
@@ -90,6 +90,7 @@ COPY python_packages.txt python_packages.txt
 
 # Pygeosimplify installed without dependencies
 # See https://github.com/g4edge/pyg4ometry/issues/243
+# TODO: installation should be moved to python_packages.txt
 RUN python3 -m ensurepip --default-pip \
  && python3 -m pip install --upgrade pip \
  && pip3 install $(cat python_packages.txt) \

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -95,6 +95,7 @@ COPY python_packages.txt python_packages.txt
 
 # Pygeosimplify installed without dependencies
 # See https://github.com/g4edge/pyg4ometry/issues/243
+# TODO: installation should be moved to python_packages.txt
 RUN pip3 install --break-system-packages --upgrade --ignore-installed pip \
  && pip3 install --break-system-packages $(cat python_packages.txt) \
  && pip3 install --break-system-packages pygeosimplify --no-deps \


### PR DESCRIPTION
Fixes a bug where github action secrets are not inherited between reusable workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated container setup instructions with improved command formatting.
	- Added inline notes to guide future enhancements in package management.
	- Enhanced GitHub Actions workflow by allowing jobs to inherit secrets for improved access to credentials.
	- Maintained all current functionality while refining configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->