### PR TITLE
Fix std::pair warning on arm64

### DIFF
--- a/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
+++ b/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
@@ -37,7 +37,7 @@ void TFCSEnergyInterpolationPiecewiseLinear::InitFromArrayInLogEkin(
   m_linInterpol.SetData(m_logEkin, m_response);
 
   auto min_max = std::minmax_element(m_logEkin.begin(), m_logEkin.end());
-  m_MinMaxlogEkin = std::make_pair(*min_max.first, *min_max.second);
+  m_MinMaxlogEkin = std::pair<double, double>(*min_max.first, *min_max.second);
 }
 
 void TFCSEnergyInterpolationPiecewiseLinear::InitFromArrayInEkin(


### PR DESCRIPTION
Fixes the following compiler warnings observed on arm64 builds:

```
In file included from /usr/include/c++/11/bits/stl_algobase.h:64,
                 from /usr/include/c++/11/bits/stl_tree.h:63,
                 from /usr/include/c++/11/map:60,
                 from /__w/FastCaloSim/FastCaloSim/include/FastCaloSim/Core/TFCSParametrizationBase.h:6,
                 from /__w/FastCaloSim/FastCaloSim/include/FastCaloSim/Core/TFCSParametrization.h:9,
                 from /__w/FastCaloSim/FastCaloSim/include/FastCaloSim/Core/TFCSEnergyInterpolationPiecewiseLinear.h:7,
                 from /__w/FastCaloSim/FastCaloSim/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx:3:
/usr/include/c++/11/bits/stl_pair.h: In instantiation of 'constexpr std::pair<typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type, typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type> std::make_pair(_T1&&, _T2&&) [with _T1 = double&; _T2 = double&; typename std::__strip_reference_wrapper<typename std::decay<_Tp2>::type>::__type = double; typename std::decay<_Tp2>::type = double; typename std::__strip_reference_wrapper<typename std::decay<_Tp>::type>::__type = double; typename std::decay<_Tp>::type = double]':
/__w/FastCaloSim/FastCaloSim/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx:40:35:   required from here
/usr/include/c++/11/bits/stl_pair.h:567:5: note: parameter passing for argument of type 'std::pair<double, double>' when C++17 is enabled changed to match C++14 in GCC 10.1
  567 |     make_pair(_T1&& __x, _T2&& __y)
      |     ^~~~~~~~~
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the internal handling of energy values for consistent precision. End-user functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->