### PR TITLE
Make get_cell virtual instead of get_cell_id

### DIFF
--- a/include/FastCaloSim/Geometry/CaloGeo.h
+++ b/include/FastCaloSim/Geometry/CaloGeo.h
@@ -41,7 +41,8 @@ public:
                            const Position& pos) const -> unsigned long long;
 
   // Retrieve the best matching cell for a given position
-  auto get_cell(unsigned int layer, const Position& pos) const -> const Cell&;
+  virtual auto get_cell(unsigned int layer,
+                        const Position& pos) const -> const Cell&;
 
   /// @brief Get the number of cells in a layer
   auto n_cells(unsigned int layer) const -> unsigned int;

--- a/include/FastCaloSim/Geometry/CaloGeo.h
+++ b/include/FastCaloSim/Geometry/CaloGeo.h
@@ -35,15 +35,14 @@ public:
             size_t rtree_cache_size = 5 * 1024 * 1024,
             size_t cell_store_cache_size = 10 * 1024 * 1024);
 
-  // Retrieve the id of the best matching cell for a given position
-  // Alternative geo handlers need to override this method
-  virtual auto get_cell_id(unsigned int layer,
-                           const Position& pos) const -> unsigned long long;
-
   // Retrieve the best matching cell for a given position
+  // Alternative geo handlers need to override this method
   virtual auto get_cell(unsigned int layer,
                         const Position& pos) const -> const Cell&;
 
+  // Retrieve the id of the best matching cell for a given position
+  auto get_cell_id(unsigned int layer,
+                   const Position& pos) const -> unsigned long long;
   /// @brief Get the number of cells in a layer
   auto n_cells(unsigned int layer) const -> unsigned int;
   /// @brief Get the total number of cells

--- a/source/Geometry/CaloGeo.cxx
+++ b/source/Geometry/CaloGeo.cxx
@@ -21,12 +21,10 @@ auto CaloGeo::get_cell(unsigned int layer,
   if (alt_it != m_alt_geo_handlers.end()) {
     // Delegate to alternative geometry handler
     const Cell& cell = alt_it->second->get_cell(layer, pos);
-    // Return an invalid cell if the alternative geometry handler returns -1
+    // Make sure returned cell is valid
     if (!cell.is_valid()) {
       throw std::runtime_error(
           "Invalid cell ID from alternative geometry handler");
-      static Cell invalid_cell;
-      return invalid_cell;
     }
     return cell;
   }

--- a/source/Geometry/CaloGeo.cxx
+++ b/source/Geometry/CaloGeo.cxx
@@ -19,17 +19,19 @@ auto CaloGeo::get_cell(unsigned int layer,
   // Check if an alternative geometry handler is set for the layer
   auto alt_it = m_alt_geo_handlers.find(layer);
   if (alt_it != m_alt_geo_handlers.end()) {
-    auto cell_id = alt_it->second->get_cell_id(layer, pos);
+    // Delegate to alternative geometry handler
+    const Cell& cell = alt_it->second->get_cell(layer, pos);
     // Return an invalid cell if the alternative geometry handler returns -1
-    if (cell_id == std::numeric_limits<unsigned long long>::max()) {
-      std::runtime_error("Invalid cell ID from alternative geometry handler");
+    if (!cell.is_valid()) {
+      throw std::runtime_error(
+          "Invalid cell ID from alternative geometry handler");
       static Cell invalid_cell;
       return invalid_cell;
     }
-    return get_cell(cell_id);
+    return cell;
   }
 
-  // Else proceed with the default geometry handler
+  // Default path: R-tree + cell store lookup
   auto query_it = m_layer_rtree_queries.find(layer);
   if (query_it == m_layer_rtree_queries.end()) {
     throw std::runtime_error("No RTree loaded for layer "
@@ -249,34 +251,6 @@ void CaloGeo::build(ROOT::RDataFrame& geo, const std::string& rtree_base_path)
       processed_layer_flags.insert(layer_id);
     }
 
-    // For RPhiZ cells, we estimate the cell's Δη if it is missing (≤ 0).
-    // RPhiZ cells are defined in cylindrical coordinates (r, φ, z)
-    // and do not have η as a primary coordinate. If deta is not provided in the
-    // input, we compute an approximate Δη by evaluating η at the four (r, z)
-    // corners of the cell and taking the span (η_max - η_min). This gives a
-    // good estimate of the angular extent, especially for projective or
-    // wedge-like cell shapes where both r and z vary.
-    //
-    // We do not apply this approximation to EtaPhiZ or EtaPhiR cells,
-    // since those coordinate systems use η as a fundamental axis
-    // and should have accurate Δη values already present in the input.
-    float deta_val = deta->at(i);
-    if (isRPhiZ->at(i) && deta_val <= 0.0f) {
-      std::array<double, 4> etas;
-      for (int corner = 0; corner < 4; ++corner) {
-        double r_sign = (corner & 1) ? 0.5 : -0.5;
-        double z_sign = (corner & 2) ? 0.5 : -0.5;
-
-        double r_val = r->at(i) + r_sign * dr->at(i);
-        double z_val = z->at(i) + z_sign * dz->at(i);
-        double theta = std::atan2(r_val, z_val);
-        etas[corner] = -std::log(std::tan(theta / 2));
-      }
-
-      auto minmax = std::minmax_element(etas.begin(), etas.end());
-      deta_val = static_cast<float>(*minmax.second - *minmax.first);
-    }
-
     pos.m_x = x->at(i);
     pos.m_y = y->at(i);
     pos.m_z = z->at(i);
@@ -295,7 +269,7 @@ void CaloGeo::build(ROOT::RDataFrame& geo, const std::string& rtree_base_path)
               dx->at(i),
               dy->at(i),
               dz->at(i),
-              deta_val,
+              deta->at(i),
               dphi->at(i),
               dr->at(i));
 

--- a/test/TestPlugins/ATLAS/ATLASFCalGeoPlugin/include/ATLASFCalGeoPlugin/FCal.h
+++ b/test/TestPlugins/ATLAS/ATLASFCalGeoPlugin/include/ATLASFCalGeoPlugin/FCal.h
@@ -27,10 +27,12 @@ public:
   virtual ~FCal() = default;
 
   /// @brief Get the cell at a specific position
-  auto get_cell_id(unsigned int layer,
-                   const Position& pos) const -> unsigned long long override
+  auto get_cell(unsigned int layer, const Position& pos) const -> const Cell&
   {
-    return this->get_fcal_cell_id(layer, pos.x(), pos.y(), pos.z());
+    unsigned long long cell_id =
+        this->get_fcal_cell_id(layer, pos.x(), pos.y(), pos.z());
+    // This will get the cell directly from the cell store
+    return CaloGeo::get_cell(cell_id);
   }
 
   /// @brief Load the real FCal geometry from a file

--- a/test/TestPlugins/ATLAS/ATLASFCalGeoPlugin/include/ATLASFCalGeoPlugin/FCal.h
+++ b/test/TestPlugins/ATLAS/ATLASFCalGeoPlugin/include/ATLASFCalGeoPlugin/FCal.h
@@ -26,13 +26,21 @@ public:
   // Virtual destructor to ensure proper cleanup
   virtual ~FCal() = default;
 
+  /// @brief Set the geo pointer
+  auto set_geo(CaloGeo* geo) { m_geo = geo; }
+
   /// @brief Get the cell at a specific position
   auto get_cell(unsigned int layer, const Position& pos) const -> const Cell&
   {
     unsigned long long cell_id =
         this->get_fcal_cell_id(layer, pos.x(), pos.y(), pos.z());
+
+    if (cell_id == static_cast<unsigned long long>(-1)) {
+      static Cell invalid_cell;
+      return invalid_cell;
+    }
     // This will get the cell directly from the cell store
-    return CaloGeo::get_cell(cell_id);
+    return m_geo->get_cell(cell_id);
   }
 
   /// @brief Load the real FCal geometry from a file
@@ -232,4 +240,7 @@ protected:
   // https://atlas-sw-doxygen.web.cern.ch/atlas-sw-doxygen/atlas_main--Doxygen/docs/html/d6/d72/FCALChannelMapBuilder_8cxx_source.html
   FCAL_ChannelMap m_FCal_ChannelMap {0};
   std::vector<double> m_FCal_rmin, m_FCal_rmax;
+
+  // Pointer to geo as we use the FastCaloSim cell store
+  CaloGeo* m_geo;
 };

--- a/test/include/AtlasGeoTests.h
+++ b/test/include/AtlasGeoTests.h
@@ -51,11 +51,10 @@ protected:
     std::shared_ptr<FCal> fcal_geo = std::make_shared<FCal>();
     // Load the FCal geometry from the files
     fcal_geo->load(AtlasGeoTestsConfig::FCAL_ELECTRODE_FILES);
-    // Cast the FCal geometry handler to the geo interface
-    std::shared_ptr<CaloGeo> fcal_geo_handler =
-        std::static_pointer_cast<CaloGeo>(fcal_geo);
+    // Set the pointer to the main geo to access cell store
+    fcal_geo->set_geo(geo);
     // Set the alternative geometry handler for the FCal layers (21 - 23)
-    geo->set_alt_geo_handler(21, 23, fcal_geo_handler);
+    geo->set_alt_geo_handler(21, 23, fcal_geo);
   }
 
   // Tears down the test suite


### PR DESCRIPTION
In the current implementation we define a virtual `get_cell_id` method for consumers to implement. The cell information was then supposed to come from the `m_cell_store`. However, for DD4hep we don't want / can't keep all cells in memory. Hence, we change `get_cell` to  be virtual instead. Consumers can still use the cell store if desired by storing a pointer to the main CaloGeo instance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to externally set the geometry pointer in the FCal geometry handler.

- **Refactor**
	- Simplified and clarified the process for retrieving cell information, now returning cell objects directly instead of cell IDs.
	- Streamlined the method for setting alternative geometry handlers, improving code clarity and maintainability.

- **Bug Fixes**
	- Improved validation when retrieving cells to ensure only valid cells are returned.

- **Chores**
	- Removed unused Δη estimation logic for RPhiZ cells, relying solely on input data for Δη values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->