### PR TITLE
Install ROOT dictionary files to lib/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,11 @@ target_include_directories(FastCaloSim_FastCaloSim
         ${Boost_INCLUDE_DIRS}
         ${LWTNN_INCLUDE_DIRS}
 )
+
 # Generate ROOT dictionary for custom classes when building a shared library
-ROOT_GENERATE_DICTIONARY(FastCaloSim_dict MODULE FastCaloSim_FastCaloSim LINKDEF include/FastCaloSim/LinkDef.h)
+set( _dictName "FastCaloSim_dict" )
+set( _libName "FastCaloSim_FastCaloSim" )
+ROOT_GENERATE_DICTIONARY( ${_dictName} MODULE ${_libName} LINKDEF include/FastCaloSim/LinkDef.h )
 
 # Deactivate compiler warnings and static analyzers for third party libraries
 # TODO: fix FCS warnings and remove FastCaloSim_FastCaloSim from list

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -34,6 +34,15 @@ install(
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
+# Install ROOT dictionary files alongside the library
+install(
+    FILES
+    "${PROJECT_BINARY_DIR}/lib${_libName}_rdict.pcm"
+    "${PROJECT_BINARY_DIR}/lib${_libName}.rootmap"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    COMPONENT FastCaloSim_Runtime
+)
+
 write_basic_package_version_file(
     "${package}ConfigVersion.cmake"
     COMPATIBILITY SameMajorVersion


### PR DESCRIPTION
ROOT_GENERATE_DICTIONARY produces a PCM and rootmap file that ROOT expects
to find alongside the shared library in lib/. These files were previously
not covered by any install rule, causing them to land in the build directory
root rather than lib/, which led to a missing PCM error at runtime.

Add an explicit install rule for the PCM and rootmap files to CMAKE_INSTALL_LIBDIR,
grouped with the existing library install rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system configuration to improve dictionary generation and artifact installation processes, enhancing consistency and reliability across different build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->