### PR TITLE
Update to onnxruntime 1.24.4

### DIFF
--- a/docker/alma9/Dockerfile
+++ b/docker/alma9/Dockerfile
@@ -48,7 +48,7 @@ RUN dnf install -y expat-devel xerces-c-devel \
 
 # Build onnxruntime for inference from source
 # See https://onnxruntime.ai/docs/build/inferencing.html for build instructions
-ARG ONNXRUNTIME_VERSION=1.16.3
+ARG ONNXRUNTIME_VERSION=1.24.4
 RUN git clone --branch v${ONNXRUNTIME_VERSION} --recursive https://github.com/Microsoft/onnxruntime.git onnx_src \
  && mkdir onnx_build && cd onnx_build \
  && ../onnx_src/build.sh --allow_running_as_root --config RelWithDebInfo --build_shared_lib --parallel $(nproc) --skip_submodule_sync --skip_tests --build_dir . \

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update -qq && apt-get -y install libxerces-c-dev \
 
 # Build onnxruntime for inference from source
 # See https://onnxruntime.ai/docs/build/inferencing.html for build instructions
-ARG ONNXRUNTIME_VERSION=1.16.3
+ARG ONNXRUNTIME_VERSION=1.24.4
 RUN git clone --branch v${ONNXRUNTIME_VERSION} --recursive https://github.com/Microsoft/onnxruntime.git onnx_src \
  && mkdir onnx_build && cd onnx_build \
  && ../onnx_src/build.sh --allow_running_as_root --config RelWithDebInfo --build_shared_lib --parallel $(nproc) --skip_submodule_sync --skip_tests --build_dir . \


### PR DESCRIPTION
Upgrades the Docker containers to ONNX Runtime 1.24.4, primarily to resolve a recurring build breakage that has made CI unreliable.

ONNX Runtime's CMake build fetches the Eigen library from GitLab at configure time. GitLab dynamically regenerates zip archives on-the-fly, which means the SHA1 hash of the downloaded file can change server-side without any code change — causing CMake's hash verification to fail with no local workaround available.
This is a known upstream issue ([microsoft/onnxruntime#18286](https://github.com/microsoft/onnxruntime/issues/18286)), fixed in [microsoft/onnxruntime#24884](https://github.com/microsoft/onnxruntime/pull/24884) and first shipped in [v1.23.0](https://github.com/microsoft/onnxruntime/releases/tag/v1.23.0).