### PR TITLE
Add HDF5 dependency to dev containers

### DIFF
--- a/docker/alma10/Dockerfile
+++ b/docker/alma10/Dockerfile
@@ -103,6 +103,22 @@ RUN git clone --branch CLHEP_${CLHEP_VERSION} --depth=1 https://gitlab.cern.ch/C
  && cmake --build . --target install -j$(nproc) \
  && rm -rf ../clhep_build
 
+# Build HDF5 from source with C++ and high-level bindings
+# See https://github.com/HDFGroup/hdf5 for instructions
+ARG HDF5_VERSION=1.14.6
+RUN git clone --branch hdf5_${HDF5_VERSION} --depth=1 https://github.com/HDFGroup/hdf5.git hdf5_src \
+ && mkdir hdf5_build && cd hdf5_build \
+ && cmake -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DBUILD_STATIC_LIBS=OFF \
+          -DHDF5_BUILD_CPP_LIB=ON \
+          -DHDF5_BUILD_TOOLS=OFF \
+          -DHDF5_BUILD_EXAMPLES=OFF \
+          -DBUILD_TESTING=OFF \
+          ../hdf5_src \
+ && cmake --build . --target install -j$(nproc) \
+ && rm -rf ../hdf5_build
+
 # Create a virtual environment
 ENV VIRT_ENV=/opt/venv
 RUN python3 -m venv $VIRT_ENV

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -102,6 +102,23 @@ RUN git clone --branch CLHEP_${CLHEP_VERSION} --depth=1 https://gitlab.cern.ch/C
  && cmake --build . --target install -j$(nproc) \
  && rm -rf ../clhep_build
 
+
+# Build HDF5 from source with C++ and high-level bindings
+# See https://github.com/HDFGroup/hdf5 for instructions
+ARG HDF5_VERSION=1.14.6
+RUN git clone --branch hdf5_${HDF5_VERSION} --depth=1 https://github.com/HDFGroup/hdf5.git hdf5_src \
+ && mkdir hdf5_build && cd hdf5_build \
+ && cmake -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+          -DBUILD_STATIC_LIBS=OFF \
+          -DHDF5_BUILD_CPP_LIB=ON \
+          -DHDF5_BUILD_TOOLS=OFF \
+          -DHDF5_BUILD_EXAMPLES=OFF \
+          -DBUILD_TESTING=OFF \
+          ../hdf5_src \
+ && cmake --build . --target install -j$(nproc) \
+ && rm -rf ../hdf5_build
+
 # Configure the clang-tidy version
 RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 180
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations across multiple environments to compile and install HDF5 directly from source during image builds. Introduces configurable HDF5 version argument (default 1.14.6). Enables C++ library support while optimizing the build by excluding static libraries, tools, examples, and testing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->