### PR TITLE
Make particle data charge lookup pluggable by experiments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 add_library(FastCaloSim_FastCaloSim SHARED "")
 
 # Add the source files
+add_subdirectory(source/Definitions)
 add_subdirectory(source/Core)
 add_subdirectory(source/Geometry)
 add_subdirectory(source/Transport)

--- a/include/FastCaloSim/Definitions/ParticleData.h
+++ b/include/FastCaloSim/Definitions/ParticleData.h
@@ -49,12 +49,14 @@ FASTCALOSIM_EXPORT auto setProvider(std::shared_ptr<const Provider> provider)
     -> void;
 
 /// The currently installed provider, or the built-in default if none was set.
-FASTCALOSIM_EXPORT auto getProvider() -> const Provider&;
+/// Returned by shared_ptr so the provider stays alive for the caller even if
+/// setProvider replaces it concurrently.
+FASTCALOSIM_EXPORT auto getProvider() -> std::shared_ptr<const Provider>;
 
 /// Convenience accessor: electric charge of the given PDG id, in units of e.
 inline auto charge(int pdgID) -> double
 {
-  return getProvider().charge(pdgID);
+  return getProvider()->charge(pdgID);
 }
 
 }  // namespace ParticleData

--- a/include/FastCaloSim/Definitions/ParticleData.h
+++ b/include/FastCaloSim/Definitions/ParticleData.h
@@ -1,31 +1,60 @@
 // Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
 
 /*
-  Class to store particle charge data. As not all possible particles are defined
-  here, experiments must provide their own implementation to ensure full
-  particle coverage. A future solution will transition to more generic
-  approaches, such as those in the AtlasPID header:
+  Access point for particle data (currently only electric charge) needed during
+  simulation.
+
+  FastCaloSim ships a small built-in table that covers the particles produced by
+  the standard parametrisations. Experiments that need fuller particle coverage
+  can provide their own implementation by deriving from ParticleData::Provider
+  and installing it once at start-up via ParticleData::setProvider, e.g.
+  wrapping a generic source such as the AtlasPID / TruthUtils helpers:
   https://gitlab.cern.ch/atlas/athena/-/blob/main/Generators/TruthUtils/TruthUtils/AtlasPID.h?ref_type=heads
+
+  All call sites use the free ParticleData::charge() function, which dispatches
+  to the installed provider (or the built-in default if none was installed).
 */
 
 #pragma once
 
-#include <stdexcept>
+#include <memory>
+
+#include <FastCaloSim/FastCaloSim_export.h>
 
 namespace ParticleData
 {
 
-constexpr auto charge(const int pdgID) -> double
+/// Interface for supplying particle data to FastCaloSim.
+///
+/// Experiments implement this to plug in their own particle database. The
+/// interface is intentionally minimal; further per-particle quantities (mass,
+/// name, stability, ...) can be added here as the need arises, and every
+/// implementation gets them through the single injection point.
+class FASTCALOSIM_EXPORT Provider
 {
-  if (pdgID == 11 || pdgID == 211 || pdgID == 2212)
-    return 1.;
-  else if (pdgID == -11 || pdgID == -211 || pdgID == -2212)
-    return -1.;
-  else if (pdgID == 22 || std::abs(pdgID) == 2112 || pdgID == 111)
-    return 0;
-  else {
-    std::runtime_error("Error: This pdgID is not supported: ");
-  }
+public:
+  virtual ~Provider() = default;
+
+  /// Electric charge of the particle with the given PDG id, in units of e.
+  /// Implementations should throw if the pdgID is not supported.
+  virtual auto charge(int pdgID) const -> double = 0;
+};
+
+/// Install the provider used by all subsequent particle data queries.
+///
+/// Intended to be called once during experiment initialization, before any
+/// simulation runs. Passing nullptr restores the built-in default provider.
+/// Not safe to call concurrently with simulation.
+FASTCALOSIM_EXPORT auto setProvider(std::shared_ptr<const Provider> provider)
+    -> void;
+
+/// The currently installed provider, or the built-in default if none was set.
+FASTCALOSIM_EXPORT auto getProvider() -> const Provider&;
+
+/// Convenience accessor: electric charge of the given PDG id, in units of e.
+inline auto charge(int pdgID) -> double
+{
+  return getProvider().charge(pdgID);
 }
 
 }  // namespace ParticleData

--- a/source/Definitions/CMakeLists.txt
+++ b/source/Definitions/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
+
+file(GLOB FastCaloSimDefinitions_SOURCES "*.cxx")
+target_sources(
+    FastCaloSim_FastCaloSim
+    PRIVATE
+    ${FastCaloSimDefinitions_SOURCES}
+)

--- a/source/Definitions/ParticleData.cxx
+++ b/source/Definitions/ParticleData.cxx
@@ -1,0 +1,58 @@
+// Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "FastCaloSim/Definitions/ParticleData.h"
+
+namespace ParticleData
+{
+
+namespace
+{
+
+/// Built-in particle data used when no experiment provider is installed.
+/// Covers only the particles produced by the standard parametrisations.
+class DefaultProvider final : public Provider
+{
+public:
+  auto charge(int pdgID) const -> double override
+  {
+    if (pdgID == 11 || pdgID == 211 || pdgID == 2212)
+      return 1.;
+    if (pdgID == -11 || pdgID == -211 || pdgID == -2212)
+      return -1.;
+    if (pdgID == 22 || std::abs(pdgID) == 2112 || pdgID == 111)
+      return 0.;
+
+    throw std::runtime_error("ParticleData: unsupported pdgID: "
+                             + std::to_string(pdgID));
+  }
+};
+
+/// The installed provider, lazily defaulting to DefaultProvider. Defined in a
+/// single translation unit and reached through the exported accessors below so
+/// that there is exactly one instance across the shared-library boundary.
+auto activeProvider() -> std::shared_ptr<const Provider>&
+{
+  static std::shared_ptr<const Provider> provider =
+      std::make_shared<const DefaultProvider>();
+  return provider;
+}
+
+}  // namespace
+
+auto setProvider(std::shared_ptr<const Provider> provider) -> void
+{
+  activeProvider() = provider ? std::move(provider)
+                              : std::make_shared<const DefaultProvider>();
+}
+
+auto getProvider() -> const Provider&
+{
+  return *activeProvider();
+}
+
+}  // namespace ParticleData

--- a/source/Definitions/ParticleData.cxx
+++ b/source/Definitions/ParticleData.cxx
@@ -50,9 +50,9 @@ auto setProvider(std::shared_ptr<const Provider> provider) -> void
                               : std::make_shared<const DefaultProvider>();
 }
 
-auto getProvider() -> const Provider&
+auto getProvider() -> std::shared_ptr<const Provider>
 {
-  return *activeProvider();
+  return activeProvider();
 }
 
 }  // namespace ParticleData


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Particle charge lookup now supports pluggable providers, allowing the active charge source to be replaced at runtime.
  * Added a built-in default provider for standard particle charges, with graceful fallback when no custom provider is set.

* **Build / Packaging**
  * Expanded the build to include the Definitions source set, so its implementations are compiled with the main library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->