### PR TITLE
Fix ST vs. MT diferences of G4CaloTransportTool

### DIFF
--- a/include/FastCaloSim/Transport/G4CaloTransportTool.h
+++ b/include/FastCaloSim/Transport/G4CaloTransportTool.h
@@ -3,6 +3,8 @@
 #ifndef G4ATLASTOOLS_G4CALOTRANSPORTTOOL_H
 #define G4ATLASTOOLS_G4CALOTRANSPORTTOOL_H
 
+#include <mutex>
+
 #include <FastCaloSim/FastCaloSim_export.h>
 
 #include "FastCaloSim/Transport/ThreadLocalHolder.h"
@@ -64,8 +66,14 @@ private:
   void doStep(G4FieldTrack& fieldTrack);
 
   /// Pointer to the physical volume of the world (either simplified or full
-  /// geometry)
+  /// geometry). Shared across all threads; created exactly once via
+  /// m_worldVolumeOnceFlag.
   G4VPhysicalVolume* m_worldVolume {};
+
+  /// Guards one-time creation of the shared world volume. Required because
+  /// initializePropagator() is called concurrently by each worker thread in
+  /// AthenaMT and getWorldVolume() mutates global Geant4 geometry stores.
+  std::once_flag m_worldVolumeOnceFlag;
 
   /// Whether to use simplified geometry for particle transport
   bool m_useSimplifiedGeo = true;

--- a/source/Transport/G4CaloTransportTool.cxx
+++ b/source/Transport/G4CaloTransportTool.cxx
@@ -32,23 +32,33 @@ void G4CaloTransportTool::initializePropagator()
   G4cout << "Initializing G4PropagatorInField for thread "
          << G4Threading::G4GetThreadId() << G4endl;
 
-  if (!m_worldVolume) {
-    // If not set, get either the simplified or full world volume
-    m_worldVolume = getWorldVolume();
+  // The world volume is shared by all threads' navigators and must be created
+  // exactly once. getWorldVolume() registers a G4PVPlacement into the global
+  // Geant4 geometry stores in the simplified-geometry case, so creating it
+  // concurrently from multiple worker threads is a data race that can produce
+  // duplicate world volumes and subtly different navigation between threads.
+  std::call_once(m_worldVolumeOnceFlag,
+                 [this]()
+                 {
+                   // Get either the simplified or full world volume
+                   m_worldVolume = getWorldVolume();
 
-    if (!m_worldVolume) {
-      G4Exception("G4CaloTransportTool",
-                  "FailedToGetWorldVolume",
-                  FatalException,
-                  "G4CaloTransportTool: Failed to get world volume.");
-      abort();
-    }
-    G4cout << "Using world volume: " << m_worldVolume->GetName() << G4endl;
-    G4cout << "Transport will be stopped at volume: " << m_transportLimitVolume
-           << G4endl;
-    G4cout << "Maximum allowed number of steps in particle transport: "
-           << m_maxSteps << G4endl;
-  }
+                   if (!m_worldVolume) {
+                     G4Exception("G4CaloTransportTool",
+                                 "FailedToGetWorldVolume",
+                                 FatalException,
+                                 "G4CaloTransportTool: Failed to get world "
+                                 "volume.");
+                     abort();
+                   }
+                   G4cout << "Using world volume: " << m_worldVolume->GetName()
+                          << G4endl;
+                   G4cout << "Transport will be stopped at volume: "
+                          << m_transportLimitVolume << G4endl;
+                   G4cout << "Maximum allowed number of steps in particle "
+                             "transport: "
+                          << m_maxSteps << G4endl;
+                 });
 
   // Check if we already have propagator set up for the current thread
   auto* propagator = m_propagatorHolder.get();


### PR DESCRIPTION

This PR is an Attempt to fix https://github.com/fcs-proj/FastCaloSim/issues/16

## Summary

Protect world volume initialization in `G4CaloTransportTool` against concurrent execution in AthenaMT.

`initializePropagator()` is invoked by multiple worker threads, while `getWorldVolume()` may modify Geant4 global geometry stores when constructing the simplified geometry. Previously, multiple threads could enter the initialization block simultaneously, potentially creating duplicate world volumes and introducing inconsistent navigation behaviour.

This PR replaces the unsynchronised lazy initialization with `std::call_once`, ensuring that the shared world volume is created exactly once and safely reused by all threads.

## Changes

- Add a `std::once_flag` to guard world volume creation.
- Replace the unsynchronised `if (!m_worldVolume)` check with `std::call_once`.
- Add documentation describing the threading assumptions and rationale for the synchronization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safe initialization during transport setup, preventing duplicate world-volume creation and inconsistent navigation when multiple threads initialize concurrently.
  * Preserved existing failure handling if the world volume cannot be obtained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->