### PR TITLE
Build G4CaloTransportTool world volume once on master thread in MT

### DIFF
--- a/include/FastCaloSim/Transport/G4CaloTransportTool.h
+++ b/include/FastCaloSim/Transport/G4CaloTransportTool.h
@@ -25,8 +25,19 @@ public:
   G4CaloTransportTool();
   ~G4CaloTransportTool();
 
-  // Initialize propagator for the current thread
-  void initializePropagator();
+  /// @brief Create the shared world volume. Must be called on the master
+  /// thread, exactly once, after the (simplified) transport geometry has been
+  /// loaded into the global Geant4 geometry stores. Building the world here
+  /// (rather than lazily on a worker thread) keeps the Geant4 split-class
+  /// per-thread data for the world volume correctly sized across all workers.
+  /// Idempotent: guarded by m_worldVolumeOnceFlag. Returns true on success
+  /// (i.e. a valid world volume is available).
+  bool initializeGeometry();
+
+  // Initialize the thread-local propagator for the current thread. Requires
+  // initializeGeometry() to have run first; returns false (without building a
+  // propagator) if the shared world volume is not available.
+  bool initializePropagator();
 
   // Transport input track through the geometry
   auto transport(const G4Track& G4InputTrack) -> std::vector<G4FieldTrack>;
@@ -70,9 +81,10 @@ private:
   /// m_worldVolumeOnceFlag.
   G4VPhysicalVolume* m_worldVolume {};
 
-  /// Guards one-time creation of the shared world volume. Required because
-  /// initializePropagator() is called concurrently by each worker thread in
-  /// AthenaMT and getWorldVolume() mutates global Geant4 geometry stores.
+  /// Guards one-time creation of the shared world volume in
+  /// initializeGeometry(). getWorldVolume() mutates the global Geant4 geometry
+  /// stores, so the world must be built exactly once (on the master thread);
+  /// the flag also protects against any accidental concurrent call.
   std::once_flag m_worldVolumeOnceFlag;
 
   /// Whether to use simplified geometry for particle transport

--- a/source/Transport/G4CaloTransportTool.cxx
+++ b/source/Transport/G4CaloTransportTool.cxx
@@ -27,16 +27,17 @@ G4CaloTransportTool::~G4CaloTransportTool()
   }
 }
 
-void G4CaloTransportTool::initializePropagator()
+bool G4CaloTransportTool::initializeGeometry()
 {
-  G4cout << "Initializing G4PropagatorInField for thread "
-         << G4Threading::G4GetThreadId() << G4endl;
-
   // The world volume is shared by all threads' navigators and must be created
-  // exactly once. getWorldVolume() registers a G4PVPlacement into the global
-  // Geant4 geometry stores in the simplified-geometry case, so creating it
-  // concurrently from multiple worker threads is a data race that can produce
-  // duplicate world volumes and subtly different navigation between threads.
+  // exactly once, on the master thread. getWorldVolume() registers a
+  // G4PVPlacement into the global Geant4 geometry stores in the
+  // simplified-geometry case; doing so concurrently from multiple worker
+  // threads (as the previous per-worker initializePropagator() did) is a data
+  // race that can produce duplicate world volumes and subtly different
+  // navigation between threads. Building it once on the master thread also
+  // keeps the Geant4 split-class per-thread data for the world correctly sized
+  // across all workers.
   std::call_once(m_worldVolumeOnceFlag,
                  [this]()
                  {
@@ -44,12 +45,12 @@ void G4CaloTransportTool::initializePropagator()
                    m_worldVolume = getWorldVolume();
 
                    if (!m_worldVolume) {
-                     G4Exception("G4CaloTransportTool",
+                     G4Exception("G4CaloTransportTool::initializeGeometry",
                                  "FailedToGetWorldVolume",
-                                 FatalException,
+                                 JustWarning,
                                  "G4CaloTransportTool: Failed to get world "
                                  "volume.");
-                     abort();
+                     return;
                    }
                    G4cout << "Using world volume: " << m_worldVolume->GetName()
                           << G4endl;
@@ -60,17 +61,36 @@ void G4CaloTransportTool::initializePropagator()
                           << m_maxSteps << G4endl;
                  });
 
-  // Check if we already have propagator set up for the current thread
+  return m_worldVolume != nullptr;
+}
+
+bool G4CaloTransportTool::initializePropagator()
+{
+  // The shared world volume must have been created on the master thread by
+  // initializeGeometry() before any worker builds its thread-local propagator.
+  if (!m_worldVolume) {
+    G4Exception("G4CaloTransportTool::initializePropagator",
+                "WorldVolumeNotInitialized",
+                JustWarning,
+                "G4CaloTransportTool: world volume is not initialized. "
+                "initializeGeometry() must be called on the master thread "
+                "before initializePropagator().");
+    return false;
+  }
+
+  // Check if we already have a propagator set up for the current thread. This
+  // method is idempotent so it can also be used as a lazy guard before
+  // transport(); it only logs and builds a propagator the first time it runs on
+  // a given thread.
   auto* propagator = m_propagatorHolder.get();
-  // If not, we create one
   if (!propagator) {
+    G4cout << "Initializing G4PropagatorInField for thread "
+           << G4Threading::G4GetThreadId() << G4endl;
     propagator = makePropagator();
     m_propagatorHolder.set(propagator);
-  } else {
-    G4cerr << "G4CaloTransportTool::initializePropagator() Propagator already "
-              "initialized!"
-           << G4endl;
   }
+
+  return true;
 }
 
 auto G4CaloTransportTool::getWorldVolume() -> G4VPhysicalVolume*
@@ -81,6 +101,20 @@ auto G4CaloTransportTool::getWorldVolume() -> G4VPhysicalVolume*
     // Get the logical world volume of the simplified geometry by name
     G4LogicalVolume* logVol = G4LogicalVolumeStore::GetInstance()->GetVolume(
         m_simplifiedWorldLogName);
+
+    if (!logVol) {
+      G4ExceptionDescription description;
+      description << "G4CaloTransportTool: simplified world logical volume '"
+                  << m_simplifiedWorldLogName
+                  << "' was not found in the G4LogicalVolumeStore. Ensure the "
+                     "simplified transport geometry is loaded before "
+                     "initializeGeometry() runs.";
+      G4Exception("G4CaloTransportTool::getWorldVolume",
+                  "MissingSimplifiedWorldLog",
+                  JustWarning,
+                  description);
+      return nullptr;
+    }
 
     // Create the physical volume of the simplified world
     return new G4PVPlacement(
@@ -158,11 +192,25 @@ void G4CaloTransportTool::doStep(G4FieldTrack& fieldTrack)
 std::vector<G4FieldTrack> G4CaloTransportTool::transport(
     const G4Track& G4InputTrack)
 {
-  // Get the navigator for the current thread
-  auto* navigator = m_propagatorHolder.get()->GetNavigatorForPropagating();
-
   // Create a vector to store the output steps
   std::vector<G4FieldTrack> outputStepVector;
+
+  // The thread-local propagator must have been built by initializePropagator()
+  // before transport() is called on this thread. Fail loudly instead of
+  // dereferencing a null propagator.
+  auto* propagator = m_propagatorHolder.get();
+  if (!propagator) {
+    G4Exception("G4CaloTransportTool::transport",
+                "PropagatorNotInitialized",
+                JustWarning,
+                "G4CaloTransportTool: no propagator for this thread. "
+                "initializeGeometry() (master) and initializePropagator() "
+                "(per thread) must be called before transport().");
+    return outputStepVector;
+  }
+
+  // Get the navigator for the current thread
+  auto* navigator = propagator->GetNavigatorForPropagating();
   // Initialize the tmpFieldTrack with the input track
   G4FieldTrack tmpFieldTrack('0');
   G4FieldTrackUpdator::Update(&tmpFieldTrack, &G4InputTrack);

--- a/test/g4app/src/FastSimModel.cc
+++ b/test/g4app/src/FastSimModel.cc
@@ -22,7 +22,23 @@ FastSimModel::FastSimModel(G4String aModelName, G4Region* aEnvelope)
   , m_debug(false)
   , fParametrization(nullptr)
 {
-  fTransportTool.initializePropagator();
+   // Build the shared world volume (once) and this thread's propagator. In this
+  // single-threaded test app both run on the same thread. Fail loudly if either
+  // step fails: continuing would silently yield empty transport results.
+  if (!fTransportTool.initializeGeometry()) {
+    G4Exception("FastSimModel::FastSimModel",
+                "TransportGeometryInitFailed",
+                FatalException,
+                "G4CaloTransportTool::initializeGeometry() failed. Ensure the "
+                "transport geometry is loaded before the model is constructed.");
+  }
+  if (!fTransportTool.initializePropagator()) {
+    G4Exception("FastSimModel::FastSimModel",
+                "TransportPropagatorInitFailed",
+                FatalException,
+                "G4CaloTransportTool::initializePropagator() failed.");
+  }
+
   m_random_engine.setSeed(42);
 }
 


### PR DESCRIPTION
PR is attempt towards tackling https://github.com/fcs-proj/FastCaloSim/issues/16

## Summary

Refactor `G4CaloTransportTool` initialization to separate shared geometry setup from thread-local propagator creation, improving thread safety in multi-threaded environments.

## Changes

- Introduce `initializeGeometry()` to create the shared Geant4 world volume exactly once on the master thread.
- Update `initializePropagator()` to only initialize thread-local propagators and return a success status.
- Add validation and error handling for missing world volumes and uninitialized propagators.
- Add defensive checks in `transport()` to avoid null dereferences.
- Improve documentation and clarify initialization requirements.
- Update the test application to explicitly initialize geometry and propagators and fail early on initialization errors.

## Motivation

Previously, the shared world volume could be created concurrently by multiple worker threads, leading to races when modifying Geant4 global geometry stores. This change ensures deterministic and thread-safe initialization of the transport geometry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved initialization handling for calorimeter transport, with a clearer startup flow that sets up shared geometry once before per-thread setup.

* **Bug Fixes**
  * Added safer checks to prevent transport from running without the required geometry or propagator, avoiding crashes and returning clear failure warnings instead.
  * Startup now fails fast with explicit error messages if required initialization steps do not complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->