### PR TITLE
feat(lib): Support an opt-in static library build (BUILD_SHARED_LIBS)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -122,6 +122,49 @@ jobs:
         if-no-files-found: error
         retention-days: 90
 
+  # Build FastCaloSim as a static, position-independent archive and verify it can
+  # be absorbed into a single shared library with its ROOT dictionary intact.
+  test_static:
+    needs: [docker-check, docker-build]
+    # Allow skipping docker-build if no Docker files changed
+    if: always() && !failure() && !cancelled()
+    runs-on: ubuntu-24.04
+
+    # If pull request with Docker file changes: use PR image, else use main
+    container:
+      image: fcsproj/fastcalosim-alma10:${{ (github.event_name == 'pull_request' && needs.docker-check.outputs.docker_changed == 'true') && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Configure
+      run: cmake "--preset=ci-static"
+
+    - name: Build
+      run: cmake --build build --config Release -j 4
+
+    - name: Verify a static archive was produced
+      run: |
+        find build -name 'libFastCaloSim.a' | grep -q . \
+          || { echo 'ERROR: libFastCaloSim.a not found'; exit 1; }
+        if find build \( -name 'libFastCaloSim.so' -o -name 'libFastCaloSim.so.*' \) | grep -q .; then
+          echo 'ERROR: a shared libFastCaloSim was produced in a static build'; exit 1
+        fi
+
+    - name: Test
+      run: ctest --test-dir build --output-on-failure --no-tests=error -C Release -j 4
+
+    - name: Install
+      run: cmake --install build --config Release --prefix prefix
+
+    - name: Verify the static build ships no autoload rootmap
+      run: |
+        if find prefix -name 'libFastCaloSim_FastCaloSim.rootmap' | grep -q .; then
+          echo 'ERROR: a core .rootmap was installed for the static build'; exit 1
+        fi
+        find prefix -name 'libFastCaloSim_FastCaloSim_rdict.pcm' | grep -q . \
+          || { echo 'ERROR: dictionary pcm was not installed'; exit 1; }
+
   # Test against LCG releases
   test_lcg:
     env:
@@ -221,7 +264,7 @@ jobs:
 
   docs:
     # Deploy docs after all other jobs are successful (allow skipping)
-    needs: [lint, coverage, test, test_lcg, test_key4hep]
+    needs: [lint, coverage, test, test_static, test_lcg, test_key4hep]
     if: always() && !failure() && !cancelled() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository_owner == 'fcs-proj'
     runs-on: ubuntu-24.04
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,16 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(cmake/project-is-top-level.cmake)
 include(cmake/variables.cmake)
 
+# ---- Library type ----
+
+# Default to a shared library for standalone builds, but let an embedding project
+# choose a static build via the standard -DBUILD_SHARED_LIBS=OFF. A static,
+# position-independent archive can be absorbed into a consumer's own shared
+# library that links its dependencies statically and exposes a single copy of them.
+if(PROJECT_IS_TOP_LEVEL AND NOT DEFINED BUILD_SHARED_LIBS)
+  set(BUILD_SHARED_LIBS ON)
+endif()
+
 # ---- Project dependencies ----
 
 # ROOT is a required dependency for FastCaloSim
@@ -61,8 +71,8 @@ endif()
 
 # ---- Declare library ----
 
-# Create a shared library
-add_library(FastCaloSim_FastCaloSim SHARED "")
+# Library type follows BUILD_SHARED_LIBS (shared by default for standalone builds).
+add_library(FastCaloSim_FastCaloSim "")
 
 # Add the source files
 add_subdirectory(source/Definitions)
@@ -98,7 +108,11 @@ target_include_directories(FastCaloSim_FastCaloSim
         ${LWTNN_INCLUDE_DIRS}
 )
 
-# Generate ROOT dictionary for custom classes when building a shared library
+# Generate ROOT dictionary for custom classes. The dictionary source is compiled
+# into the target, so it is generated for both shared and static builds; the
+# TFCS* classes must have a dictionary at runtime to read the parametrization
+# file. (The accompanying .rootmap is only shipped for the shared build; see the
+# install rules for why it is skipped in a static build.)
 set( _dictName "FastCaloSim_dict" )
 set( _libName "FastCaloSim_FastCaloSim" )
 ROOT_GENERATE_DICTIONARY( ${_dictName} MODULE ${_libName} LINKDEF include/FastCaloSim/LinkDef.h )
@@ -117,6 +131,7 @@ generate_export_header(
 
 set_target_properties(
     FastCaloSim_FastCaloSim PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN YES
     VERSION "${PROJECT_VERSION}"
@@ -154,6 +169,22 @@ endif()
 
 if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/install-rules.cmake)
+endif()
+
+# ---- Embed test ----
+
+# Optional check that the library can be absorbed, whole-archive, into a single
+# consumer shared library with its ROOT dictionary still self-registering at
+# runtime. This is the configuration used when the library is built as a static,
+# position-independent archive (BUILD_SHARED_LIBS=OFF). It is deliberately kept
+# separate from developer-mode tests, whose shared helper libraries would each
+# pull in their own copy of a static library.
+if(PROJECT_IS_TOP_LEVEL)
+  option(FastCaloSim_BUILD_EMBED_TEST "Build the embed dictionary check" OFF)
+  if(FastCaloSim_BUILD_EMBED_TEST)
+    enable_testing()
+    add_subdirectory(test/static-embed)
+  endif()
 endif()
 
 # ---- Developer mode ----

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -133,6 +133,17 @@
         "linux",
         "dev-mode"
       ]
+    },
+    {
+      "name": "ci-static",
+      "inherits": [
+        "ci-build",
+        "linux"
+      ],
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "FastCaloSim_BUILD_EMBED_TEST": "ON"
+      }
     }
   ]
 }

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -34,14 +34,24 @@ install(
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
-# Install ROOT dictionary files alongside the library
+# Install ROOT dictionary files alongside the library. The precompiled module
+# carries the dictionary payload and is needed at runtime in both build modes.
 install(
-    FILES
-    "${PROJECT_BINARY_DIR}/lib${_libName}_rdict.pcm"
-    "${PROJECT_BINARY_DIR}/lib${_libName}.rootmap"
+    FILES "${PROJECT_BINARY_DIR}/lib${_libName}_rdict.pcm"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     COMPONENT FastCaloSim_Runtime
 )
+
+# Autoloading only makes sense for a shared library; in a static build the
+# classes are compiled directly into the consumer, so skip the .rootmap that
+# would otherwise point at a nonexistent libFastCaloSim.so.
+if(BUILD_SHARED_LIBS)
+  install(
+      FILES "${PROJECT_BINARY_DIR}/lib${_libName}.rootmap"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      COMPONENT FastCaloSim_Runtime
+  )
+endif()
 
 write_basic_package_version_file(
     "${package}ConfigVersion.cmake"

--- a/test/static-embed/CMakeLists.txt
+++ b/test/static-embed/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
+
+# Verifies that FastCaloSim can be absorbed, whole-archive, into a single shared
+# library and that its ROOT dictionary still self-registers at runtime. This is
+# the configuration an embedding consumer uses when it links FastCaloSim as a
+# static, position-independent archive into one of its own shared libraries.
+#
+# The whole-archive link feature ($<LINK_LIBRARY:WHOLE_ARCHIVE,...>) needs
+# CMake >= 3.24.
+if(CMAKE_VERSION VERSION_LESS 3.24)
+  message(FATAL_ERROR
+    "FastCaloSim_BUILD_EMBED_TEST requires CMake >= 3.24 for whole-archive linking")
+endif()
+
+# Absorb FastCaloSim into a single shared library. Whole-archive keeps the ROOT
+# dictionary translation unit (which self-registers the TFCS* classes) from being
+# dropped by the linker as unreferenced when FastCaloSim is a static archive.
+# Building this shared library against a static archive also exercises that the
+# archive is position-independent.
+add_library(fcs_embed SHARED probe.cxx)
+target_link_libraries(
+    fcs_embed PRIVATE
+    "$<LINK_LIBRARY:WHOLE_ARCHIVE,FastCaloSim::FastCaloSim>"
+)
+deactivate_checks(fcs_embed)
+
+# A thin driver that asks whether the dictionaries are present in the absorbed
+# library. Kept free of any FastCaloSim/ROOT headers so it only depends on the
+# absorbing shared library.
+add_executable(static_embed_check main.cxx)
+target_link_libraries(static_embed_check PRIVATE fcs_embed)
+deactivate_checks(static_embed_check)
+
+add_test(NAME StaticEmbedDictionary COMMAND static_embed_check)

--- a/test/static-embed/main.cxx
+++ b/test/static-embed/main.cxx
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 CERN for the benefit of the FastCaloSim project
+
+#include <cstdio>
+
+// Provided by the shared library that absorbed the FastCaloSim archive.
+auto fcs_count_missing_dictionaries() -> int;
+
+auto main() -> int
+{
+  const int missing = fcs_count_missing_dictionaries();
+  if (missing != 0) {
+    std::printf("%d FastCaloSim dictionary(ies) missing after embedding\n",
+                missing);
+    return 1;
+  }
+  std::printf("all checked FastCaloSim dictionaries present after embedding\n");
+  return 0;
+}

--- a/test/static-embed/probe.cxx
+++ b/test/static-embed/probe.cxx
@@ -25,7 +25,7 @@ const char* const kClasses[] = {
 }  // namespace
 
 // Returns the number of expected dictionaries that are missing (0 == success).
-static auto fcs_count_missing_dictionaries() -> int
+auto fcs_count_missing_dictionaries() -> int
 {
   int missing = 0;
   for (const char* name : kClasses) {

--- a/test/static-embed/probe.cxx
+++ b/test/static-embed/probe.cxx
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 CERN for the benefit of the FastCaloSim project
+
+#include <cstdio>
+
+#include "TClass.h"
+
+// A representative spread of FastCaloSim classes that are streamed back from
+// the parametrization file at runtime. Their ROOT dictionaries live in
+// FastCaloSim's generated dictionary translation unit; if that unit were
+// dropped when the static archive was absorbed into this shared library, the
+// lookups below would return null.
+namespace
+{
+const char* const kClasses[] = {
+    "TFCSParametrizationBase",
+    "TFCSParametrization",
+    "TFCSInvisibleParametrization",
+    "TFCSEnergyInterpolationLinear",
+    "TFCSPCAEnergyParametrization",
+    "TFCSParametrizationEbinChain",
+    "TFCSTruthState",
+    "TFCSExtrapolationState",
+    "TFCSSimulationState",
+};
+}  // namespace
+
+// Returns the number of expected dictionaries that are missing (0 == success).
+static auto fcs_count_missing_dictionaries() -> int
+{
+  int missing = 0;
+  for (const char* name : kClasses) {
+    if (TClass::GetClass(name) == nullptr) {
+      std::printf("missing dictionary: %s\n", name);
+      ++missing;
+    }
+  }
+  return missing;
+}


### PR DESCRIPTION
### Summary
Lets FastCaloSim optionally be built as a **static, position-independent archive** via the standard `-DBUILD_SHARED_LIBS=OFF`, instead of always producing a shared library. The default is unchanged (shared for standalone builds); static is purely opt-in for consumers that need it.

### Motivation — why ATLAS needs this
ATLAS/Athena links **Geant4 as a static build** and folds *all* Geant4-dependent code into a **single shared library** (`libAtlasGeant4.so`), exporting **no** Geant4 symbols.

When FastCaloSim is delivered as its own **shared** library in that environment, it links static Geant4 privately and therefore embeds a **second, independent copy of Geant4** in the process. Two Geant4 instances in one process breaks things in ways that are hard to diagnose:

- **Multithreaded crashes.** Geant4 keeps state in static / thread-local singletons — the run manager's world-volume list, the per-thread transportation manager, the geometry navigation stores. With two copies, the master→worker world hand-off in an MT job operates on the wrong instance and the workers crash.
- **Transport finds no geometry.** FastCaloSim's particle transport navigates *its own* copy's geometry stores, which are empty — the geometry the host actually built lives in the other copy. Extrapolation/transport then finds nothing.

Hidden Geant4 symbols make this unavoidable for a separate `.so`: it can't borrow the host's Geant4 at runtime, so it's stuck with its private copy.

Building FastCaloSim as a static PIC archive fixes it structurally: the archive's objects (and their Geant4 references) are **absorbed into the host's single Geant4 library at link time**, so the whole process shares **one** Geant4 — the host's.

### Why opt-in, not the new default
This only matters for ATLAS's unusual setup: (1) Geant4 built as **static** archives, and (2) all Geant4 code concatenated into **one** shared library with Geant4 symbols hidden. The common case (a **shared** Geant4, e.g. from LCG) has FastCaloSim's shared library link the same `libG4*.so` as everything else → a single Geant4 already → nothing to fix. So the shared default keeps serving standalone/analysis users, and the static option accommodates the static-Geant4 / single-blob host.

### What changed
- **`CMakeLists.txt`**: library type follows `BUILD_SHARED_LIBS` (defaulted to `ON` only when FastCaloSim is the top-level project); `POSITION_INDEPENDENT_CODE ON` so the archive can be linked into a shared library.
- **ROOT dictionary**: still built in **both** modes (the `TFCS*` classes must have a dictionary at runtime to read the parametrization file). Only the autoload `.rootmap` is withheld from the static build, where there is no `libFastCaloSim.so` to autoload.
- **CI**: a `ci-static` preset and a **parallel** `test_static` job that builds the static archive and, in an isolated embed subproject, whole-archives it into a single shared library and asserts the `TFCS*` ROOT dictionaries self-register at runtime — i.e. exactly the absorb-into-one-`.so` scenario ATLAS uses.

### Downstream integration (ATLAS — not in this PR)
In `atlasexternals` (`External/FastCaloSim/CMakeLists.txt`), opt in via the `ExternalProject_Add(... CMAKE_CACHE_ARGS ...)`:

```
-DBUILD_SHARED_LIBS:BOOL=OFF
-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
```

- `FindFastCaloSim.cmake` needs no change — `find_library` locates the `.a` when no `.so` exists.
- The resulting `libFastCaloSim.a` is absorbed into `libAtlasGeant4.so`, so FastCaloSim shares the host's single Geant4.
- The `TFCS*` dictionary is kept. If its self-registration translation unit gets stripped when the archive is absorbed, whole-archive the FastCaloSim static lib in the Athena link that pulls it in — an Athena-side link flag, not an FCS change.

### Testing
- Default shared build unchanged: `cmake -S . -B build && cmake --build build` → `libFastCaloSim.so`, existing tests pass.
- Static build: `cmake -S . -B build-static -DBUILD_SHARED_LIBS=OFF` → `libFastCaloSim.a` (PIC); new `test_static` CI job builds it and verifies the dictionary works after whole-archive absorption, and that no autoload `.rootmap` is installed.

