### PR TITLE
fix(lib): Keep MLogging out of the ROOT dictionary so logging-only consumers stay light

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,19 +171,22 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
     include(cmake/install-rules.cmake)
 endif()
 
-# ---- Embed test ----
+# ---- Embed tests ----
 
-# Optional check that the library can be absorbed, whole-archive, into a single
-# consumer shared library with its ROOT dictionary still self-registering at
-# runtime. This is the configuration used when the library is built as a static,
-# position-independent archive (BUILD_SHARED_LIBS=OFF). It is deliberately kept
-# separate from developer-mode tests, whose shared helper libraries would each
-# pull in their own copy of a static library.
+# Optional checks for the two corners of embedding the library as a static,
+# position-independent archive (BUILD_SHARED_LIBS=OFF): test/static-embed
+# absorbs the whole archive into a single consumer shared library and requires
+# the ROOT dictionary to still self-register at runtime; test/static-light
+# links only the lightweight logging class and requires that it does not drag
+# in the heavy dependency closure. They are deliberately kept separate from
+# developer-mode tests, whose shared helper libraries would each pull in their
+# own copy of a static library.
 if(PROJECT_IS_TOP_LEVEL)
   option(FastCaloSim_BUILD_EMBED_TEST "Build the embed dictionary check" OFF)
   if(FastCaloSim_BUILD_EMBED_TEST)
     enable_testing()
     add_subdirectory(test/static-embed)
+    add_subdirectory(test/static-light)
   endif()
 endif()
 

--- a/include/FastCaloSim/Core/MLogging.h
+++ b/include/FastCaloSim/Core/MLogging.h
@@ -5,9 +5,9 @@
 
 #include <iomanip>
 #include <iostream>
+#include <string>
 
 #include <FastCaloSim/FastCaloSim_export.h>
-#include <TNamed.h>  //for ClassDef
 
 namespace FCS_MSG
 {
@@ -71,6 +71,10 @@ typedef std::ostream MsgStream;
 // Force a new line, and end any stream
 #define FCS_ENDMSG this->streamerEndLine(FCS_MSG::INFO)
 
+// This transient mixin is deliberately kept out of the ROOT dictionary (no
+// ClassDef): a dictionary entry would tie its vtable to the library's single
+// dictionary translation unit, forcing consumers that only want logging to
+// link the full dependency closure of the heavy parametrization classes.
 class FASTCALOSIM_EXPORT MLogging
 {
 public:
@@ -135,9 +139,6 @@ private:
   mutable FCS_MSG::Level m_streamer_has_lvl =
       FCS_MSG::NIL;  //! Do not persistify!
   mutable std::string m_streamer_from_file = "";  //! Do not persistify!
-
-  // Version number 0 to tell ROOT not to store this.
-  ClassDef(MLogging, 0)
 };
 }  // namespace ISF_FCS
 

--- a/include/FastCaloSim/Core/TFCSParametrizationBase.h
+++ b/include/FastCaloSim/Core/TFCSParametrizationBase.h
@@ -8,6 +8,7 @@
 #include <set>
 
 #include <FastCaloSim/FastCaloSim_export.h>
+#include <TNamed.h>
 
 #include "FastCaloSim/Core/MLogging.h"
 

--- a/include/FastCaloSim/LinkDef.h
+++ b/include/FastCaloSim/LinkDef.h
@@ -20,7 +20,6 @@
 #include "FastCaloSim/Core/TFCS2DFunctionTemplateInterpolationHistogram.h"
 #include "FastCaloSim/Core/TFCS2DFunctionTemplateInterpolationExpHistogram.h"
 
-#include "FastCaloSim/Core/MLogging.h"
 #include "FastCaloSim/Core/TFCSParametrizationBase.h"
 #include "FastCaloSim/Core/TFCSParametrizationPlaceholder.h"
 #include "FastCaloSim/Core/TFCSParametrization.h"
@@ -587,7 +586,6 @@
 
 #pragma link C++ class TFCS2DFunction + ;
 #pragma link C++ class TFCS2DFunctionHistogram + ;
-#pragma link C++ class ISF_FCS::MLogging + ;
 #pragma link C++ class TFCSParametrizationBase + ;
 #pragma link C++ class TFCSParametrizationPlaceholder + ;
 #pragma link C++ class TFCSParametrization + ;

--- a/source/Core/MLogging.cxx
+++ b/source/Core/MLogging.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
 
+#include <sstream>
+
 #include "FastCaloSim/Core/MLogging.h"
 
 // Declare the class in a namespace

--- a/test/static-light/CMakeLists.txt
+++ b/test/static-light/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
+
+# Verifies the opposite corner from test/static-embed: a consumer that uses
+# only the lightweight logging utility (FastCaloSim/Core/MLogging.h) must be
+# able to build the relevant part of the FastCaloSim archive into its own
+# shared library WITHOUT FastCaloSim's heavy dependency closure (ROOT
+# RDataFrame, HDF5, lwtnn, onnxruntime, libspatialindex, libxml2, ...).
+#
+# The archive is linked as a raw file (not the CMake target) so that none of
+# the target's interface link dependencies reach the link line, and
+# --no-undefined turns any reference that escapes the light path -- for
+# example the logging class dragging in the monolithic ROOT dictionary
+# translation unit -- into a hard link error.
+add_library(fcs_light_consumer SHARED light_consumer.cxx)
+target_include_directories(
+    fcs_light_consumer PRIVATE
+    "$<TARGET_PROPERTY:FastCaloSim::FastCaloSim,INTERFACE_INCLUDE_DIRECTORIES>"
+)
+target_link_libraries(
+    fcs_light_consumer PRIVATE
+    "$<TARGET_FILE:FastCaloSim::FastCaloSim>"
+)
+target_link_options(fcs_light_consumer PRIVATE "LINKER:--no-undefined")
+add_dependencies(fcs_light_consumer FastCaloSim_FastCaloSim)
+deactivate_checks(fcs_light_consumer)
+
+# A thin driver that emits a log line through the absorbed logging class.
+add_executable(static_light_check main.cxx)
+target_link_libraries(static_light_check PRIVATE fcs_light_consumer)
+deactivate_checks(static_light_check)
+
+add_test(NAME StaticLightLogging COMMAND static_light_check)

--- a/test/static-light/light_consumer.cxx
+++ b/test/static-light/light_consumer.cxx
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
+
+#include "FastCaloSim/Core/MLogging.h"
+
+// A minimal consumer of the lightweight logging mixin, deliberately using
+// nothing else from FastCaloSim: pulling in the logger must not require the
+// heavy dependency closure (see CMakeLists.txt in this directory).
+namespace
+{
+class LightLogger : public ISF_FCS::MLogging
+{
+public:
+  void greet() const { FCS_MSG_INFO("light logging path works"); }
+};
+}  // namespace
+
+// Called by the driver executable.
+auto fcs_emit_light_log_line() -> int
+{
+  LightLogger logger;
+  logger.setLevel(FCS_MSG::DEBUG);
+  logger.greet();
+  return 0;
+}

--- a/test/static-light/main.cxx
+++ b/test/static-light/main.cxx
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
+
+// Provided by the shared library that absorbed the lightweight logging part
+// of the FastCaloSim archive.
+auto fcs_emit_light_log_line() -> int;
+
+auto main() -> int
+{
+  return fcs_emit_light_log_line();
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a second static embedding validation path alongside the existing one, expanding build-time test coverage.
  * Added a new lightweight logging test to verify logging works for minimal consumers.

* **Bug Fixes**
  * Improved compatibility for static builds by adjusting how logging and related test components are handled.

* **Chores**
  * Updated build/test configuration and internal test wiring to include the new validation target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->