### PR TITLE
fix(cmake): Export lwtnn and libxml2 as real targets so the package stay relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,16 +96,17 @@ target_link_libraries(
         libspatialindex::spatialindex
     PRIVATE
         ONNXRuntime::ONNXRuntime
-        ${LWTNN_LIBRARIES}
-        ${LibXml2_LIBRARIES}
+        lwtnn::lwtnn
+        PkgConfig::LibXml2
 )
 
-# Add the include directory to the target
+# Add the include directory to the target. lwtnn's include dirs now arrive via
+# the lwtnn::lwtnn interface, and libxml2's via PkgConfig::LibXml2, so neither
+# needs a manual entry here.
 target_include_directories(FastCaloSim_FastCaloSim
     PRIVATE
         ${CMAKE_SOURCE_DIR}/include/FastCaloSim
         ${Boost_INCLUDE_DIRS}
-        ${LWTNN_INCLUDE_DIRS}
 )
 
 # Generate ROOT dictionary for custom classes. The dictionary source is compiled

--- a/cmake/modules/Findlibxml.cmake
+++ b/cmake/modules/Findlibxml.cmake
@@ -1,5 +1,3 @@
+# Locate the pinned libxml-2.0 API via pkg-config and expose it as a target.
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(LibXml2 REQUIRED libxml-2.0)
-include_directories(${LibXml2_INCLUDE_DIRS})
-link_directories(${LibXml2_LIBRARY_DIRS})
-add_definitions(${LibXml2_CFLAGS_OTHER})
+pkg_check_modules(LibXml2 REQUIRED IMPORTED_TARGET libxml-2.0)

--- a/cmake/modules/Findlwtnn.cmake
+++ b/cmake/modules/Findlwtnn.cmake
@@ -49,6 +49,18 @@ if(LWTNN_LIBRARY)
    set(LWTNN_LIBRARY_DIRS ${LWTNN_LIBRARY_DIR})
 endif()
 
+# Expose a relocatable imported target (mirrors FindONNXRuntime.cmake) so that
+# consumers link against a namespaced target instead of a build-tree-specific
+# absolute path. The flat LWTNN_* variables above are kept intact for any code
+# that still reads them; this is purely additive.
+if(LWTNN_LIBRARY AND NOT TARGET lwtnn::lwtnn)
+   add_library(lwtnn::lwtnn UNKNOWN IMPORTED)
+   set_target_properties(lwtnn::lwtnn PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LWTNN_INCLUDE_DIRS}"
+      IMPORTED_LOCATION "${LWTNN_LIBRARY}"
+   )
+endif()
+
 # Debug messages
 message(STATUS "LWTNN_ROOT: ${LWTNN_ROOT}")
 message(STATUS "LWTNN_INCLUDE_DIR: ${LWTNN_INCLUDE_DIR}")

--- a/param/CMakeLists.txt
+++ b/param/CMakeLists.txt
@@ -35,18 +35,21 @@ target_link_libraries(
         FastCaloSim::FastCaloSim
 )
 
-# Generate ROOT dictionary for custom classes when building a shared library
-ROOT_GENERATE_DICTIONARY(FastCaloSimParam_dict MODULE FastCaloSim_Param LINKDEF include/FastCaloSimParam/LinkDef.h)
-
-# Deacticate checks for the generated dictionary
-deactivate_checks(FastCaloSimParam_dict FastCaloSim_Param)
-
-# Add include directories for the generated dictionary
+# Add include directories for the generated dictionary. This MUST precede the
+# ROOT_GENERATE_DICTIONARY call below: the ROOT macro reads the module target's
+# INCLUDE_DIRECTORIES property at call time to build the dictionary's include
+# path, so the property has to be populated first.
 target_include_directories(
     FastCaloSim_Param ${warning_guard}
     PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
 )
+
+# Generate ROOT dictionary for custom classes when building a shared library
+ROOT_GENERATE_DICTIONARY(FastCaloSimParam_dict MODULE FastCaloSim_Param LINKDEF include/FastCaloSimParam/LinkDef.h)
+
+# Deacticate checks for the generated dictionary
+deactivate_checks(FastCaloSimParam_dict FastCaloSim_Param)
 
 # Set the shared library properties
 set_target_properties(


### PR DESCRIPTION
## Summary

The installed `FastCaloSimTargets.cmake` embedded a build-tree-specific absolute
path for `lwtnn` (e.g. `/srv/.../liblwtnn.so`) and a bare, unnamespaced `xml2`
entry in `FastCaloSim::FastCaloSim`'s `INTERFACE_LINK_LIBRARIES`, because the
custom Find modules exposed dependencies via flat variables instead of imported
targets.

This PR modernizes the dependency handling by introducing relocatable imported
targets and linking against those instead.

### Changes

- **Findlwtnn.cmake**
  - Add a relocatable `lwtnn::lwtnn` `UNKNOWN IMPORTED` target (mirroring
    `FindONNXRuntime.cmake`).
  - Preserve the existing `LWTNN_*` variables for backwards compatibility.

- **Findlibxml.cmake**
  - Switch to
    `pkg_check_modules(LibXml2 REQUIRED IMPORTED_TARGET libxml-2.0)` to expose
    `PkgConfig::LibXml2`.
  - Remove the directory-scoped
    `include_directories()`, `link_directories()`, and `add_definitions()`
    calls that leaked configuration into unrelated targets.

- **CMakeLists.txt**
  - Link against `lwtnn::lwtnn` and `PkgConfig::LibXml2` instead of
    `${LWTNN_LIBRARIES}` and `${LibXml2_LIBRARIES}`.
  - Remove the now-redundant `${LWTNN_INCLUDE_DIRS}`, as it is propagated
    through the `lwtnn::lwtnn` interface.

No runtime behavior changes; this only modernizes how dependencies are
expressed to CMake.

## Bug surfaced and fix

This change exposed an existing ordering bug in `param/CMakeLists.txt` that had
previously been masked by the old `Findlibxml.cmake`.

`ROOT_GENERATE_DICTIONARY(... MODULE FastCaloSim_Param ...)` was invoked before
`target_include_directories(FastCaloSim_Param ...)`, so the target initially had
no `INCLUDE_DIRECTORIES` property.

`ROOT_GENERATE_DICTIONARY` performs an unguarded
`get_target_property(... INCLUDE_DIRECTORIES)` followed by a `foreach()` over
the result. When the property is unset, CMake returns
`target_incdirs-NOTFOUND`, which is later passed to
`target_include_directories()` for the generated dictionary, causing the
generate-time error:

```
The following variables are used in this project, but they are set to NOTFOUND:
target_incdirs
```

On `main`, this bug was hidden because the previous `Findlibxml.cmake` called
directory-scoped `include_directories(${LibXml2_INCLUDE_DIRS})`. CMake copies
directory include paths into targets at creation time, so `FastCaloSim_Param`
was born with a non-empty `INCLUDE_DIRECTORIES` property and ROOT never
encountered the `NOTFOUND` case.

The fix is simply to ensure that `FastCaloSim_Param` has its include directories
configured before `ROOT_GENERATE_DICTIONARY()` is invoked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build integration for neural-network and XML dependencies, making linkage more consistent across environments.
  * Reduced reliance on legacy build variables, which should help avoid configuration issues when dependencies are relocated or provided through package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->