### PR TITLE
fix(lib): Restore default-value semantics for TFCSSimulationState/TFCSExtrapolationState accessors

### DIFF
--- a/include/FastCaloSim/Core/TFCSExtrapolationState.h
+++ b/include/FastCaloSim/Core/TFCSExtrapolationState.h
@@ -66,37 +66,58 @@ public:
 
   auto OK(int layer, int subpos) const -> bool
   {
-    return m_CaloOK.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_CaloOK.find({layer, subpos});
+    return it != m_CaloOK.end() ? it->second : false;
   }
 
   auto eta(int layer, int subpos) const -> double
   {
-    return m_etaCalo.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_etaCalo.find({layer, subpos});
+    return it != m_etaCalo.end() ? it->second : -999;
   }
 
   auto phi(int layer, int subpos) const -> double
   {
-    return m_phiCalo.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_phiCalo.find({layer, subpos});
+    return it != m_phiCalo.end() ? it->second : -999;
   }
 
   auto r(int layer, int subpos) const -> double
   {
-    return m_rCalo.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_rCalo.find({layer, subpos});
+    return it != m_rCalo.end() ? it->second : 0;
   }
 
   auto z(int layer, int subpos) const -> double
   {
-    return m_zCalo.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_zCalo.find({layer, subpos});
+    return it != m_zCalo.end() ? it->second : 0;
   }
 
   auto d(int layer, int subpos) const -> double
   {
-    return m_dCalo.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_dCalo.find({layer, subpos});
+    return it != m_dCalo.end() ? it->second : 0;
   }
 
   auto detaBorder(int layer, int subpos) const -> double
   {
-    return m_distetaCaloBorder.at({layer, subpos});
+    // layers/subpositions never reached by the extrapolation are not stored;
+    // read as the pre-map default
+    auto it = m_distetaCaloBorder.find({layer, subpos});
+    return it != m_distetaCaloBorder.end() ? it->second : 0;
   }
 
   // Boundary getters

--- a/include/FastCaloSim/Core/TFCSSimulationState.h
+++ b/include/FastCaloSim/Core/TFCSSimulationState.h
@@ -35,9 +35,18 @@ public:
 
   bool is_valid() const { return m_Ebin >= 0; };
   double E() const { return m_Etot; };
-  // NOTE: in the current implementation layers without energy are not stored
-  double E(int sample) const { return m_E.at(sample); };
-  double Efrac(int sample) const { return m_Efrac.at(sample); };
+  // NOTE: layers without energy are not stored in the maps; as for the
+  // original array-based implementation, such layers read as 0 energy.
+  double E(int sample) const
+  {
+    auto it = m_E.find(sample);
+    return it != m_E.end() ? it->second : 0.;
+  };
+  double Efrac(int sample) const
+  {
+    auto it = m_Efrac.find(sample);
+    return it != m_Efrac.end() ? it->second : 0.;
+  };
   int Ebin() const { return m_Ebin; };
 
   void set_Ebin(int bin) { m_Ebin = bin; };

--- a/source/Core/TFCSExtrapolationState.cxx
+++ b/source/Core/TFCSExtrapolationState.cxx
@@ -36,18 +36,16 @@ void TFCSExtrapolationState::Print(Option_t*) const
 
 void TFCSExtrapolationState::clear()
 {
-  // Clear all unordered_maps and reset with default values
-  for (int layer = 0; layer < m_CaloOK.size(); ++layer) {
-    for (int subpos = 0; subpos < NumSubPos; ++subpos) {
-      m_CaloOK[{layer, subpos}] = false;
-      m_etaCalo[{layer, subpos}] = -999;
-      m_phiCalo[{layer, subpos}] = -999;
-      m_rCalo[{layer, subpos}] = 0;
-      m_zCalo[{layer, subpos}] = 0;
-      m_dCalo[{layer, subpos}] = 0;
-      m_distetaCaloBorder[{layer, subpos}] = 0;
-    }
-  }
+  // Drop all stored layer/subpos entries. The getters return the default
+  // values (OK=false, eta/phi=-999, r/z/d/detaBorder=0) for entries that are
+  // not stored, so no pre-filling is needed.
+  m_CaloOK.clear();
+  m_etaCalo.clear();
+  m_phiCalo.clear();
+  m_rCalo.clear();
+  m_zCalo.clear();
+  m_dCalo.clear();
+  m_distetaCaloBorder.clear();
 
   // Reset IDCaloBoundary variables
   m_IDCaloBoundary_eta = -999;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing extrapolation and simulation data so lookups no longer fail when a layer, subposition, or sample was never stored.
  * Returned default values for absent energy and geometry entries instead of throwing errors.
  * Streamlined state reset behavior to preserve the same default outputs while avoiding unnecessary prepopulation of internal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->