### PR TITLE
fix(lib): Propagate geometry to TFCSEnergyAndHitGANV2's own chain in set_geometry

### DIFF
--- a/include/FastCaloSim/Core/TFCSEnergyAndHitGANV2.h
+++ b/include/FastCaloSim/Core/TFCSEnergyAndHitGANV2.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
+// Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
 #ifndef ISF_FASTCALOSIMEVENT_TFCSEnergyAndHitGANV2_h
 #define ISF_FASTCALOSIMEVENT_TFCSEnergyAndHitGANV2_h
@@ -25,7 +25,11 @@ public:
                         const char* title = nullptr,
                         CaloGeo* geo = nullptr);
 
-  virtual void set_geometry(CaloGeo* geo) override { m_geo = geo; };
+  virtual void set_geometry(CaloGeo* geo) override
+  {
+    m_geo = geo;
+    TFCSParametrizationBase::set_geometry(geo);
+  };
 
   virtual ~TFCSEnergyAndHitGANV2();
 


### PR DESCRIPTION
Fixes a bug in the GAN simulation where geometry would not get propagated correctly. We don't have CI tests for the GAN simulation yet, so this was not caught before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry handling during setup, which should help ensure consistent simulation behavior.
  * Updated the file metadata year.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->