### PR TITLE
fix(lib): Reset navigator stack/state in transport() to fully clear stuck-track push state

### DIFF
--- a/source/Transport/G4CaloTransportTool.cxx
+++ b/source/Transport/G4CaloTransportTool.cxx
@@ -234,6 +234,14 @@ std::vector<G4FieldTrack> G4CaloTransportTool::transport(
   // thread, breaking single-threaded vs multi-threaded reproducibility.
   propagator->ClearPropagatorState();
   G4FieldManagerStore::GetInstance()->ClearAllChordFindersState();
+  // ResetStackAndState clears the navigator state the relocation below does
+  // not: the zero-step/push machinery (fLastStepWasZero, fPushed,
+  // fNumberZeroSteps, fLocatedOnEdge) and the navigator's own cached safety.
+  // Normal tracking clears these per track via ResetHierarchyAndLocate ->
+  // ResetState in G4SteppingManager::SetInitialStep; without the equivalent
+  // here they persist across transport() calls and can alter the stuck-track
+  // push behavior of the next transport, i.e. carry state across events.
+  navigator->ResetStackAndState();
   navigator->LocateGlobalPointAndSetup(
       tmpFieldTrack.GetPosition(), nullptr, /*relativeSearch=*/false);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transport stability by fully resetting cached navigator state between successive runs on the same thread.
  * Reduced the chance of stale transport state affecting safety, push, or stuck-track behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->