### PR TITLE
fix(lib): Initialize dummy query positions in extrapolateToLayers

### DIFF
--- a/source/Extrapolation/FastCaloSimCaloExtrapolation.cxx
+++ b/source/Extrapolation/FastCaloSimCaloExtrapolation.cxx
@@ -182,8 +182,9 @@ void FastCaloSimCaloExtrapolation::extrapolateToLayers(
           // extrapolation else extrapolate to cylinder with symmetrized maximum
           // Z bounds set eta to a dummy value of 1000 and -1000 to force
           // detector side
-          Position pos_eta, neg_eta;
-          pos_eta.m_phi, neg_eta.m_phi = result.IDCaloBoundary_phi();
+          Position pos_eta {}, neg_eta {};
+          pos_eta.m_phi = result.IDCaloBoundary_phi();
+          neg_eta.m_phi = result.IDCaloBoundary_phi();
           pos_eta.m_eta = 1000;
           neg_eta.m_eta = -1000;
           if (sample < 4) {


### PR DESCRIPTION
## Summary

Fixes an uninitialized read in `FastCaloSimCaloExtrapolation::extrapolateToLayers`. The dummy query positions used to look up the reference z-surface had their `phi` set with a comma expression instead of two assignments, so one of them was read uninitialized. This is a real bug regardless of its downstream effect, and it's a plausible contributor to the single- vs multi-threaded differences we've been chasing — though that part isn't confirmed yet (see Notes).

`extrapolateToLayers` builds two placeholder positions, `pos_eta` and `neg_eta`, with `eta` forced to +1000/-1000 as a detector-side selector, and `phi` meant to come from `IDCaloBoundary_phi()`:

```cpp
Position pos_eta, neg_eta;
pos_eta.m_phi, neg_eta.m_phi = result.IDCaloBoundary_phi();
```

The second line is a comma expression, not two assignments — it evaluates `pos_eta.m_phi` and discards it, and only assigns `neg_eta.m_phi`. `Position` has no default member initializers and the locals weren't brace-initialized, so `pos_eta.m_phi` was left as indeterminate stack memory.

That value isn't inert: `pos_eta` flows into `zpos()` → `get_cell()` → `RTreeQuery::query_point()`, which reads `phi` for eta/phi-keyed layers. It's used directly for positive-eta tracks in the `sample < 4` branch, and it always feeds the averaged `cylZ` in the barrel `sample >= 4` branch.

The bug is migration-introduced: the old lookup took a scalar `eta` (no `phi`); moving to the 2D `CaloGeo`/`RTree` `Position` signature added these locals and the comma-expression typo.


Assign both `phi` values in separate statements, and value-initialize `pos_eta` and `neg_eta` so every coordinate is defined — the latter also covers the case where a layer is looked up by `(x, y)`, which were likewise uninitialized in both locals.
