### PR TITLE
Port upstream Athena improvements from main

### DIFF
--- a/include/FastCaloSim/Core/TFCS1DFunctionHistogram.h
+++ b/include/FastCaloSim/Core/TFCS1DFunctionHistogram.h
@@ -3,6 +3,7 @@
 #ifndef ISF_FASTCALOSIMEVENT_TFCS1DFunctionHistogram_h
 #define ISF_FASTCALOSIMEVENT_TFCS1DFunctionHistogram_h
 
+#include <memory>
 #include <vector>
 
 #include "FastCaloSim/Core/TFCS1DFunction.h"
@@ -28,12 +29,12 @@ public:
   void smart_rebin_loop(TH1* hist, double);
   static double get_change(TH1*);
   static TH1D* smart_rebin(TH1D*);
-  static double* histo_to_array(TH1*);
+  static std::unique_ptr<double[]> histo_to_array(TH1*);
   static double sample_from_histo(TH1* hist, double);
   double sample_from_histovalues(double);
 
-  std::vector<float> get_HistoBorders() { return m_HistoBorders; };
-  std::vector<float> get_HistoContents() { return m_HistoContents; };
+  const std::vector<float>& get_HistoBorders() { return m_HistoBorders; };
+  const std::vector<float>& get_HistoContents() { return m_HistoContents; };
 
 protected:
   std::vector<float> m_HistoBorders;

--- a/include/FastCaloSim/Core/TFCS1DFunctionHistogram.h
+++ b/include/FastCaloSim/Core/TFCS1DFunctionHistogram.h
@@ -33,8 +33,11 @@ public:
   static double sample_from_histo(TH1* hist, double);
   double sample_from_histovalues(double);
 
-  const std::vector<float>& get_HistoBorders() { return m_HistoBorders; };
-  const std::vector<float>& get_HistoContents() { return m_HistoContents; };
+  const std::vector<float>& get_HistoBorders() const { return m_HistoBorders; };
+  const std::vector<float>& get_HistoContents() const
+  {
+    return m_HistoContents;
+  };
 
 protected:
   std::vector<float> m_HistoBorders;

--- a/include/FastCaloSim/Core/TFCS1DFunctionRegressionTF.h
+++ b/include/FastCaloSim/Core/TFCS1DFunctionRegressionTF.h
@@ -22,8 +22,8 @@ public:
 private:
   std::vector<std::vector<double>> m_fWeightMatrix0to1;
   std::vector<std::vector<double>> m_fWeightMatrix1to2;
-  float m_rangeval;
-  float m_startval;
+  float m_rangeval {};
+  float m_startval {};
 
   ClassDef(TFCS1DFunctionRegressionTF, 1)
 };

--- a/include/FastCaloSim/Core/TFCSBinnedShower.h
+++ b/include/FastCaloSim/Core/TFCSBinnedShower.h
@@ -22,29 +22,29 @@ class CaloGeo;
 class TFCSBinnedShower : public TFCSBinnedShowerBase
 {
 public:
-  typedef struct
+  struct layer_t
   {
     std::vector<unsigned int> bin_index_vector;
     std::vector<float> E_vector;
-  } layer_t;
+  };
 
-  typedef struct
+  struct event_t
   {
     std::vector<layer_t> event_data;
-    float phi_mod;
-    float center_eta;
-    float e_init;  // Initial energy of the event
-  } event_t;
+    float phi_mod {};
+    float center_eta {};
+    float e_init {};  // Initial energy of the event
+  };
 
   typedef std::vector<event_t> eventvector_t;
 
-  typedef struct
+  struct layer_bins_t
   {
     std::vector<float> R_lower;
     std::vector<float> R_size;
     std::vector<float> alpha_lower;
     std::vector<float> alpha_size;
-  } layer_bins_t;
+  };
 
   typedef std::vector<layer_bins_t> event_bins_t;
 
@@ -102,20 +102,20 @@ public:
   // is stored and not loaded on the fly.
   void set_hdf5_path(const std::string& filename) { m_hdf5_file = filename; }
   void delete_hdf5_path() { m_hdf5_file.clear(); }
-  const std::string get_hdf5_path() const { return m_hdf5_file; }
+  const std::string& get_hdf5_path() const { return m_hdf5_file; }
 
   // Allows to set the layer energy for the given layer and event manually.
   void set_layer_energy(long unsigned int event_index,
                         long unsigned int layer_index,
-                        const std::vector<unsigned int> bin_index_vector,
-                        const std::vector<float> E_vector);
+                        const std::vector<unsigned int>& bin_index_vector,
+                        const std::vector<float>& E_vector);
 
   // Allows to set the voxel boundaries for the given layer manually.
   void set_bin_boundaries(long unsigned int layer_index,
-                          std::vector<float> R_lower,
-                          std::vector<float> R_size,
-                          std::vector<float> alpha_lower,
-                          std::vector<float> alpha_size);
+                          const std::vector<float>& R_lower,
+                          const std::vector<float>& R_size,
+                          const std::vector<float>& alpha_lower,
+                          const std::vector<float>& alpha_size);
 
   // Allows to set the shower center for the given event manually.
   // The layer is needed as reference for the phi modulation calculation.
@@ -125,35 +125,35 @@ public:
                                      float eta_center,
                                      float phi_center);
 
-  eventvector_t get_eventlibrary() { return m_eventlibrary; }
+  const eventvector_t& get_eventlibrary() { return m_eventlibrary; }
 
-  void set_event_library(eventvector_t eventlibrary)
+  void set_event_library(const eventvector_t& eventlibrary)
   {
     m_eventlibrary = eventlibrary;
   }
 
-  event_bins_t get_coordinates() { return m_coordinates; }
+  const event_bins_t& get_coordinates() { return m_coordinates; }
 
-  void set_coordinates(event_bins_t coordinates)
+  void set_coordinates(const event_bins_t& coordinates)
   {
     m_coordinates = coordinates;
   }
 
-  std::vector<std::vector<std::vector<std::vector<float>>>>
+  const std::vector<std::vector<std::vector<std::vector<float>>>>&
   get_sub_bin_distribution() const
   {
     return m_sub_bin_distribution;
   }
 
-  std::vector<float> get_upscaling_energies() const
+  const std::vector<float>& get_upscaling_energies() const
   {
     return m_upscaling_energies;
   }
 
   void set_sub_bin_distribution_and_energies(
-      std::vector<std::vector<std::vector<std::vector<float>>>>
+      const std::vector<std::vector<std::vector<std::vector<float>>>>&
           sub_bin_distribution,
-      std::vector<float> upscaling_energies)
+      const std::vector<float>& upscaling_energies)
   {
     m_sub_bin_distribution = sub_bin_distribution;
     m_upscaling_energies = upscaling_energies;

--- a/include/FastCaloSim/Core/TFCSBinnedShower.h
+++ b/include/FastCaloSim/Core/TFCSBinnedShower.h
@@ -125,14 +125,14 @@ public:
                                      float eta_center,
                                      float phi_center);
 
-  const eventvector_t& get_eventlibrary() { return m_eventlibrary; }
+  const eventvector_t& get_eventlibrary() const { return m_eventlibrary; }
 
   void set_event_library(const eventvector_t& eventlibrary)
   {
     m_eventlibrary = eventlibrary;
   }
 
-  const event_bins_t& get_coordinates() { return m_coordinates; }
+  const event_bins_t& get_coordinates() const { return m_coordinates; }
 
   void set_coordinates(const event_bins_t& coordinates)
   {

--- a/include/FastCaloSim/Core/TFCSBinnedShowerONNX.h
+++ b/include/FastCaloSim/Core/TFCSBinnedShowerONNX.h
@@ -75,7 +75,7 @@ public:
                           const std::vector<float>& alpha_lower,
                           const std::vector<float>& alpha_size);
 
-  const event_bins_t& get_coordinates() { return m_coordinates; }
+  const event_bins_t& get_coordinates() const { return m_coordinates; }
 
   void set_coordinates(const event_bins_t& coordinates)
   {

--- a/include/FastCaloSim/Core/TFCSBinnedShowerONNX.h
+++ b/include/FastCaloSim/Core/TFCSBinnedShowerONNX.h
@@ -22,13 +22,13 @@ class CaloGeo;
 class TFCSBinnedShowerONNX : public TFCSBinnedShowerBase
 {
 public:
-  typedef struct
+  struct layer_bins_t
   {
     std::vector<float> R_lower;
     std::vector<float> R_size;
     std::vector<float> alpha_lower;
     std::vector<float> alpha_size;
-  } layer_bins_t;
+  };
 
   typedef std::vector<layer_bins_t> event_bins_t;
 
@@ -70,33 +70,33 @@ public:
 
   // Allows to set the voxel boundaries for the given layer manually.
   void set_bin_boundaries(long unsigned int layer_index,
-                          std::vector<float> R_lower,
-                          std::vector<float> R_size,
-                          std::vector<float> alpha_lower,
-                          std::vector<float> alpha_size);
+                          const std::vector<float>& R_lower,
+                          const std::vector<float>& R_size,
+                          const std::vector<float>& alpha_lower,
+                          const std::vector<float>& alpha_size);
 
-  event_bins_t get_coordinates() { return m_coordinates; }
+  const event_bins_t& get_coordinates() { return m_coordinates; }
 
-  void set_coordinates(event_bins_t coordinates)
+  void set_coordinates(const event_bins_t& coordinates)
   {
     m_coordinates = coordinates;
   }
 
-  std::vector<std::vector<std::vector<std::vector<float>>>>
+  const std::vector<std::vector<std::vector<std::vector<float>>>>&
   get_sub_bin_distribution() const
   {
     return m_sub_bin_distribution;
   }
 
-  std::vector<float> get_upscaling_energies() const
+  const std::vector<float>& get_upscaling_energies() const
   {
     return m_upscaling_energies;
   }
 
   void set_sub_bin_distribution_and_energies(
-      std::vector<std::vector<std::vector<std::vector<float>>>>
+      const std::vector<std::vector<std::vector<std::vector<float>>>>&
           sub_bin_distribution,
-      std::vector<float> upscaling_energies)
+      const std::vector<float>& upscaling_energies)
   {
     m_sub_bin_distribution = sub_bin_distribution;
     m_upscaling_energies = upscaling_energies;

--- a/include/FastCaloSim/Core/TFCSEnergyAndHitGANV2.h
+++ b/include/FastCaloSim/Core/TFCSEnergyAndHitGANV2.h
@@ -3,6 +3,7 @@
 #ifndef ISF_FASTCALOSIMEVENT_TFCSEnergyAndHitGANV2_h
 #define ISF_FASTCALOSIMEVENT_TFCSEnergyAndHitGANV2_h
 
+#include <mutex>
 #include <string>
 
 #include "FastCaloSim/Core/TFCSGANEtaSlice.h"
@@ -84,7 +85,7 @@ public:
   {
     return m_param.GetBinning();
   };
-  const TFCSGANEtaSlice::ExtrapolatorWeights get_ExtrapolationWeights() const
+  const TFCSGANEtaSlice::ExtrapolatorWeights& get_ExtrapolationWeights() const
   {
     return m_slice->GetExtrapolatorWeights();
   };
@@ -111,7 +112,7 @@ protected:
                                 std::string FastCaloGANInputFolderName);
 
 private:
-  static int GetBinsInFours(double const& bins);
+  static int GetBinsInFours(double const bins);
   int GetAlphaBinsForRBin(const TAxis* x, int ix, int yBinNum) const;
 
   std::vector<int> m_bin_ninit;
@@ -123,6 +124,7 @@ private:
 
   TFCSGANEtaSlice* m_slice = nullptr;
   TFCSGANXMLParameters m_param;
+  mutable std::mutex m_mutex;  //! Do not persistify
 
   ClassDefOverride(TFCSEnergyAndHitGANV2, 2)  // TFCSEnergyAndHitGANV2
 };

--- a/include/FastCaloSim/Core/TFCSFlatLateralShapeParametrization.h
+++ b/include/FastCaloSim/Core/TFCSFlatLateralShapeParametrization.h
@@ -51,9 +51,9 @@ public:
 
 protected:
   /// Simulate hits flat in radius dR
-  float m_dR;
-  float m_nhits;
-  float m_scale;
+  float m_dR {};
+  float m_nhits {};
+  float m_scale {};
 
 private:
   ClassDefOverride(TFCSFlatLateralShapeParametrization,

--- a/include/FastCaloSim/Core/TFCSGANEtaSlice.h
+++ b/include/FastCaloSim/Core/TFCSGANEtaSlice.h
@@ -34,6 +34,9 @@ public:
                   const TFCSGANXMLParameters& param);
   virtual ~TFCSGANEtaSlice();
 
+  TFCSGANEtaSlice(const TFCSGANEtaSlice&) = delete;
+  TFCSGANEtaSlice& operator=(const TFCSGANEtaSlice&) = delete;
+
   typedef std::map<int, std::vector<double>> FitResultsPerLayer;
   typedef std::map<int, double> ExtrapolatorWeights;
   typedef std::map<std::string, std::map<std::string, double>> NetworkInputs;
@@ -45,18 +48,21 @@ public:
 
   NetworkOutputs GetNetworkOutputs(const TFCSTruthState* truth,
                                    const TFCSExtrapolationState* extrapol,
-                                   TFCSSimulationState simulstate) const;
+                                   TFCSSimulationState& simulstate) const;
 
   bool IsGanCorrectlyLoaded() const;
-  FitResultsPerLayer GetFitResults() const { return m_allFitResults; }
-  ExtrapolatorWeights GetExtrapolatorWeights() { return m_extrapolatorWeights; }
+  const FitResultsPerLayer& GetFitResults() const { return m_allFitResults; }
+  const ExtrapolatorWeights& GetExtrapolatorWeights()
+  {
+    return m_extrapolatorWeights;
+  }
 
   void Print() const;
 
 private:
-  int m_pid;
-  int m_etaMin;
-  int m_etaMax;
+  int m_pid {};
+  int m_etaMin {};
+  int m_etaMax {};
 
   std::string m_inputFolderName;
 

--- a/include/FastCaloSim/Core/TFCSGANEtaSlice.h
+++ b/include/FastCaloSim/Core/TFCSGANEtaSlice.h
@@ -52,7 +52,7 @@ public:
 
   bool IsGanCorrectlyLoaded() const;
   const FitResultsPerLayer& GetFitResults() const { return m_allFitResults; }
-  const ExtrapolatorWeights& GetExtrapolatorWeights()
+  const ExtrapolatorWeights& GetExtrapolatorWeights() const
   {
     return m_extrapolatorWeights;
   }

--- a/include/FastCaloSim/Core/TFCSGANXMLParameters.h
+++ b/include/FastCaloSim/Core/TFCSGANXMLParameters.h
@@ -8,15 +8,11 @@
 #define ISF_TFCSGANXMLPARAMETERS_H 1
 
 #include <map>
+#include <string>
 #include <vector>
 
 // XML reader
-#include <libxml/parser.h>
 #include <libxml/tree.h>
-#include <libxml/xmlmemory.h>
-#include <libxml/xmlreader.h>
-#include <libxml/xpath.h>
-#include <libxml/xpathInternals.h>
 
 #include "FastCaloSim/Core/MLogging.h"
 #include "TH2D.h"
@@ -34,21 +30,27 @@ public:
                          const std::string& FastCaloGANInputFolderName);
   void Print() const;
 
-  std::vector<int> GetRelevantLayers() const { return m_relevantlayers; };
+  const std::vector<int>& GetRelevantLayers() const
+  {
+    return m_relevantlayers;
+  };
   const Binning& GetBinning() const { return m_binning; };
   int GetLatentSpaceSize() const { return m_latentDim; };
   int GetGANVersion() const { return m_ganVersion; };
   bool IsSymmetrisedAlpha() const { return m_symmetrisedAlpha; };
-  std::string GetInputFolder() const { return m_fastCaloGANInputFolderName; };
+  const std::string& GetInputFolder() const
+  {
+    return m_fastCaloGANInputFolderName;
+  };
 
 private:
   static bool ReadBooleanAttribute(const std::string& name, xmlNodePtr node);
 
-  bool m_symmetrisedAlpha;
+  bool m_symmetrisedAlpha {};
   Binning m_binning;
   std::vector<int> m_relevantlayers;
-  int m_ganVersion;
-  int m_latentDim;
+  int m_ganVersion {};
+  int m_latentDim {};
   std::string m_fastCaloGANInputFolderName;
 
   ClassDef(TFCSGANXMLParameters, 1)  // TFCSGANXMLParameters

--- a/include/FastCaloSim/Core/TFCSHitCellMappingWiggle.h
+++ b/include/FastCaloSim/Core/TFCSHitCellMappingWiggle.h
@@ -25,6 +25,8 @@ public:
                   const std::vector<float>& bin_low_edges,
                   float xscale = 1);
 
+  void clear();
+
   inline unsigned int get_number_of_bins() const { return m_functions.size(); };
 
   inline double get_bin_low_edge(int bin) const { return m_bin_low_edge[bin]; };
@@ -37,11 +39,11 @@ public:
   {
     return m_functions[bin];
   };
-  const std::vector<const TFCS1DFunction*> get_functions()
+  const std::vector<const TFCS1DFunction*>& get_functions()
   {
     return m_functions;
   };
-  const std::vector<float> get_bin_low_edges() { return m_bin_low_edge; };
+  const std::vector<float>& get_bin_low_edges() { return m_bin_low_edge; };
 
   /// modify one hit position to emulate the LAr accordion shape
   /// and then fills all hits into calorimeter cells

--- a/include/FastCaloSim/Core/TFCSHitCellMappingWiggle.h
+++ b/include/FastCaloSim/Core/TFCSHitCellMappingWiggle.h
@@ -39,11 +39,14 @@ public:
   {
     return m_functions[bin];
   };
-  const std::vector<const TFCS1DFunction*>& get_functions()
+  const std::vector<const TFCS1DFunction*>& get_functions() const
   {
     return m_functions;
   };
-  const std::vector<float>& get_bin_low_edges() { return m_bin_low_edge; };
+  const std::vector<float>& get_bin_low_edges() const
+  {
+    return m_bin_low_edge;
+  };
 
   /// modify one hit position to emulate the LAr accordion shape
   /// and then fills all hits into calorimeter cells

--- a/include/FastCaloSim/Core/TFCSLateralShapeParametrizationFluctChain.h
+++ b/include/FastCaloSim/Core/TFCSLateralShapeParametrizationFluctChain.h
@@ -33,7 +33,7 @@ public:
   void Print(Option_t* option) const override;
 
 private:
-  float m_RMS;
+  float m_RMS {};
 
   ClassDefOverride(TFCSLateralShapeParametrizationFluctChain,
                    1)  // TFCSLateralShapeParametrizationFluctChain

--- a/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitBase.h
+++ b/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitBase.h
@@ -53,6 +53,7 @@ public:
     Hit(float eta, float phi, float E)
         : m_eta_x(eta)
         , m_phi_y(phi)
+        , m_z(0.)
         , m_E(E)
         , m_useXYZ(false)
         , m_center_r(0.)
@@ -147,7 +148,7 @@ public:
     float m_center_z;
     float m_center_eta;
     float m_center_phi;
-    long unsigned int m_hit_index;
+    long unsigned int m_hit_index {};
   };
 
   /// simulated one hit position with some energy. As last step in

--- a/include/FastCaloSim/Core/TFCSMLCalorimeterSimulator.h
+++ b/include/FastCaloSim/Core/TFCSMLCalorimeterSimulator.h
@@ -18,18 +18,18 @@ public:
   TFCSMLCalorimeterSimulator();
   virtual ~TFCSMLCalorimeterSimulator();
 
-  typedef struct
+  struct layer_t
   {
     std::vector<unsigned int> bin_index_vector;
     std::vector<float> E_vector;
-  } layer_t;
+  };
 
-  typedef struct
+  struct event_t
   {
     std::vector<layer_t> event_data;
-  } event_t;
+  };
 
-  bool loadSimulator(std::string filename);
+  bool loadSimulator(const std::string& filename);
 
   void Print() const;
 

--- a/include/FastCaloSim/Core/TFCSPhiModulationCorrection.h
+++ b/include/FastCaloSim/Core/TFCSPhiModulationCorrection.h
@@ -25,7 +25,7 @@ public:
 
   virtual ~TFCSPhiModulationCorrection();
 
-  void load_phi_modulation(std::string filename,
+  void load_phi_modulation(const std::string& filename,
                            long unsigned int layer_index,
                            float eta_min,
                            float eta_max,
@@ -39,16 +39,19 @@ public:
     m_energy_shift.clear();
   };
 
-  std::vector<std::vector<std::vector<float>>> get_phi_modulation() const
+  const std::vector<std::vector<std::vector<float>>>& get_phi_modulation() const
   {
     return m_modulation;
   };
-  std::vector<std::vector<float>> get_min_eta() const { return m_min_eta; };
-  std::vector<std::vector<float>> get_energy_shift() const
+  const std::vector<std::vector<float>>& get_min_eta() const
+  {
+    return m_min_eta;
+  };
+  const std::vector<std::vector<float>>& get_energy_shift() const
   {
     return m_energy_shift;
   };
-  std::vector<std::vector<std::vector<float>>> get_min_phi() const
+  const std::vector<std::vector<std::vector<float>>>& get_min_phi() const
   {
     return m_min_phi;
   };

--- a/include/FastCaloSim/Core/TFCSSimulationState.h
+++ b/include/FastCaloSim/Core/TFCSSimulationState.h
@@ -18,7 +18,7 @@ namespace CLHEP
 class HepRandomEngine;
 }
 
-constexpr std::uint32_t operator"" _FCShash(char const* s, std::size_t count);
+constexpr std::uint32_t operator""_FCShash(char const* s, std::size_t count);
 
 class FASTCALOSIM_EXPORT TFCSSimulationState
     : public TObject
@@ -209,7 +209,7 @@ inline void TFCSSimulationState::AuxInfo_t::set<void*>(void* val)
 
 // Implementation of the compile time text hash operator that can be used for
 // human readable indices to the AuxInfo
-constexpr std::uint32_t operator"" _FCShash(char const* s, std::size_t count)
+constexpr std::uint32_t operator""_FCShash(char const* s, std::size_t count)
 {
   return TFCSSimulationState::fnv1a_32(s, count);
 }

--- a/include/FastCaloSim/Core/TFCSVoxelHistoLateralCovarianceFluctuations.h
+++ b/include/FastCaloSim/Core/TFCSVoxelHistoLateralCovarianceFluctuations.h
@@ -49,8 +49,8 @@ protected:
   std::vector<std::vector<std::vector<TFCS1DFunction*>>> m_transform;
 
   // For a 5*5 cell grid, nDim should be 5
-  int m_nDim_x;
-  int m_nDim_y;
+  int m_nDim_x {};
+  int m_nDim_y {};
   std::vector<TH2*> m_voxel_template;
   std::vector<TVectorD> m_parMeans;
   std::vector<TMatrixD> m_EigenVectors;  // Eigen-vectors of covariance

--- a/include/FastCaloSim/Extrapolation/FastCaloSimCaloExtrapolation.h
+++ b/include/FastCaloSim/Extrapolation/FastCaloSimCaloExtrapolation.h
@@ -19,7 +19,7 @@ struct CylinderIntersections
 {
   Vector3D first;
   Vector3D second;
-  unsigned int number;
+  unsigned int number = 0;
 };
 
 class FASTCALOSIM_EXPORT FastCaloSimCaloExtrapolation : public ISF_FCS::MLogging

--- a/param/include/FastCaloSimParam/FCS_Cell.h
+++ b/param/include/FastCaloSimParam/FCS_Cell.h
@@ -5,6 +5,8 @@
 #ifndef FCS_Cell
 #define FCS_Cell
 
+#include <algorithm>  // std::sort, std::remove_if
+#include <cmath>  // std::fabs
 #include <vector>
 
 #include <Rtypes.h>
@@ -12,12 +14,12 @@
 
 struct FCS_cell
 {
-  Long64_t cell_identifier;
-  int sampling;
-  float energy;
-  float center_x;
-  float center_y;
-  float center_z;  // to be updated later
+  Long64_t cell_identifier {};
+  int sampling {};
+  float energy {};
+  float center_x {};
+  float center_y {};
+  float center_z {};  // to be updated later
   auto operator<(const FCS_cell& rhs) const -> bool
   {
     return energy > rhs.energy;
@@ -26,30 +28,28 @@ struct FCS_cell
 
 struct FCS_hit  // this is the FCS detailed hit
 {
-  Long64_t identifier;  // hit in the same tile cell can have two identifiers
-                        // (for two PMTs)
-  Long64_t cell_identifier;
-  int sampling;  // calorimeter layer
-  float hit_energy;  // energy is already scaled for the sampling fraction
-  float hit_time;
-  float hit_x;
-  float hit_y;
-  float hit_z;
+  Long64_t identifier {};  // hit in the same tile cell can have two
+                           // identifiers (for two PMTs)
+  Long64_t cell_identifier {};
+  int sampling {};  // calorimeter layer
+  float hit_energy {};  // energy is already scaled for the sampling fraction
+  float hit_time {};
+  float hit_x {};
+  float hit_y {};
+  float hit_z {};
   auto operator<(const FCS_hit& rhs) const -> bool
   {
     return hit_energy > rhs.hit_energy;
   };
-  // float  hit_sampfrac;
 };
 
 struct FCS_g4hit  // this is the standard G4Hit
 {
-  Long64_t identifier;
-  Long64_t cell_identifier;
-  int sampling;
-  float hit_energy;
-  float hit_time;
-  // float  hit_sampfrac;
+  Long64_t identifier {};
+  Long64_t cell_identifier {};
+  int sampling {};
+  float hit_energy {};
+  float hit_time {};
   auto operator<(const FCS_g4hit& rhs) const -> bool
   {
     return hit_energy > rhs.hit_energy;
@@ -122,7 +122,10 @@ struct FCS_matchedcellvector  // this is the matched structure for the whole
     return m_vector[place];
   };
   inline auto size() const -> unsigned int { return m_vector.size(); };
-  inline void push_back(FCS_matchedcell cell) { m_vector.push_back(cell); };
+  inline void push_back(const FCS_matchedcell& cell)
+  {
+    m_vector.push_back(cell);
+  };
   inline void sort_cells() { std::sort(m_vector.begin(), m_vector.end()); };
   inline void sort()
   {
@@ -136,14 +139,15 @@ struct FCS_matchedcellvector  // this is the matched structure for the whole
     for (auto& i : m_vector) {
       i.time_trim(timing_cut);
     };
-    m_vector.erase(std::remove_if(m_vector.begin(),
-                                  m_vector.end(),
-                                  [](const FCS_matchedcell& rhs)
-                                  {
-                                    return (rhs.hit.empty() && rhs.g4hit.empty()
-                                            && fabs(rhs.cell.energy) < 1e-3);
-                                  }),
-                   m_vector.end());
+    m_vector.erase(
+        std::remove_if(m_vector.begin(),
+                       m_vector.end(),
+                       [](const FCS_matchedcell& rhs)
+                       {
+                         return (rhs.hit.empty() && rhs.g4hit.empty()
+                                 && std::fabs(rhs.cell.energy) < 1e-3);
+                       }),
+        m_vector.end());
   };
   inline auto scalingfactor() -> float
   {

--- a/source/Core/TFCS1DFunction.cxx
+++ b/source/Core/TFCS1DFunction.cxx
@@ -3,6 +3,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS1DFunction.h"
@@ -29,17 +30,23 @@ double TFCS1DFunction::get_maxdev(TH1* h_input1, TH1* h_approx1)
   // normalize the histos to the same area:
   double integral_input = h_input->Integral();
   double integral_approx = 0.0;
-  for (int b = 1; b <= h_input->GetNbinsX(); b++)
+  for (int b = 1; b <= h_input->GetNbinsX(); b++) {
     integral_approx +=
         h_approx->GetBinContent(h_approx->FindBin(h_input->GetBinCenter(b)));
+  }
+  if (integral_approx == 0.0) {
+    delete h_input;
+    delete h_approx;
+    return 0.;
+  }
   h_approx->Scale(integral_input / integral_approx);
 
   double ymax = h_approx->GetBinContent(h_approx->GetNbinsX())
       - h_approx->GetBinContent(h_approx->GetMinimumBin());
   for (int i = 1; i <= h_input->GetNbinsX(); i++) {
-    double val = fabs(h_approx->GetBinContent(
-                          h_approx->FindBin(h_input->GetBinCenter(i)))
-                      - h_input->GetBinContent(i))
+    double val = std::abs(h_approx->GetBinContent(
+                              h_approx->FindBin(h_input->GetBinCenter(i)))
+                          - h_input->GetBinContent(i))
         / ymax;
     if (val > maxdev)
       maxdev = val;
@@ -64,7 +71,7 @@ double TFCS1DFunction::CheckAndIntegrate1DHistogram(
     if (binval < 0) {
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
-      if (TMath::Abs(fraction) > 1e-5) {
+      if (std::abs(fraction) > 1e-5) {
         FCS_MSG_NOCLASS(logger,
                         "Warning: bin content is negative in histogram "
                             << hist->GetName() << " : " << hist->GetTitle()

--- a/source/Core/TFCS1DFunctionHistogram.cxx
+++ b/source/Core/TFCS1DFunctionHistogram.cxx
@@ -1,5 +1,8 @@
 // Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS1DFunctionHistogram.h"
@@ -24,15 +27,17 @@ void TFCS1DFunctionHistogram::Initialize(TH1* hist, double cut_maxdev)
 
 std::unique_ptr<double[]> TFCS1DFunctionHistogram::histo_to_array(TH1* hist)
 {
-  TH1D* h_clone = (TH1D*)hist->Clone("h_clone");
-  h_clone->Scale(1.0 / h_clone->Integral());
+  std::unique_ptr<TH1D> h_clone(static_cast<TH1D*>(hist->Clone("h_clone")));
+  const double integral = h_clone->Integral();
+  if (integral != 0) {
+    h_clone->Scale(1.0 / integral);
+  }
 
   auto histoVals = std::make_unique<double[]>(h_clone->GetNbinsX());
   histoVals[0] = h_clone->GetBinContent(1);
   for (int i = 1; i < h_clone->GetNbinsX(); i++) {
     histoVals[i] = histoVals[i - 1] + h_clone->GetBinContent(i + 1);
   }
-  delete h_clone;
   return histoVals;
 }
 

--- a/source/Core/TFCS1DFunctionHistogram.cxx
+++ b/source/Core/TFCS1DFunctionHistogram.cxx
@@ -22,12 +22,12 @@ void TFCS1DFunctionHistogram::Initialize(TH1* hist, double cut_maxdev)
   smart_rebin_loop(hist, cut_maxdev);
 }
 
-double* TFCS1DFunctionHistogram::histo_to_array(TH1* hist)
+std::unique_ptr<double[]> TFCS1DFunctionHistogram::histo_to_array(TH1* hist)
 {
   TH1D* h_clone = (TH1D*)hist->Clone("h_clone");
   h_clone->Scale(1.0 / h_clone->Integral());
 
-  double* histoVals = new double[h_clone->GetNbinsX()];
+  auto histoVals = std::make_unique<double[]>(h_clone->GetNbinsX());
   histoVals[0] = h_clone->GetBinContent(1);
   for (int i = 1; i < h_clone->GetNbinsX(); i++) {
     histoVals[i] = histoVals[i - 1] + h_clone->GetBinContent(i + 1);
@@ -38,14 +38,11 @@ double* TFCS1DFunctionHistogram::histo_to_array(TH1* hist)
 
 double TFCS1DFunctionHistogram::sample_from_histo(TH1* hist, double random)
 {
-  double* histoVals = histo_to_array(hist);
+  auto histoVals = histo_to_array(hist);
   double value = 0.0;
   int chosenBin =
-      (int)TMath::BinarySearch(hist->GetNbinsX(), histoVals, random);
+      (int)TMath::BinarySearch(hist->GetNbinsX(), histoVals.get(), random);
   value = hist->GetBinCenter(chosenBin + 2);
-
-  // cleanup
-  delete[] histoVals;
 
   return value;
 }
@@ -56,9 +53,9 @@ double TFCS1DFunctionHistogram::sample_from_histovalues(double random)
 
   TH1* hist = vector_to_histo();
   hist->SetName("hist");
-  double* histoVals = histo_to_array(hist);
+  auto histoVals = histo_to_array(hist);
   int chosenBin =
-      (int)TMath::BinarySearch(hist->GetNbinsX(), histoVals, random);
+      (int)TMath::BinarySearch(hist->GetNbinsX(), histoVals.get(), random);
   value = hist->GetBinCenter(chosenBin + 2);
 
   return value;

--- a/source/Core/TFCS1DFunctionRegression.cxx
+++ b/source/Core/TFCS1DFunctionRegression.cxx
@@ -20,23 +20,12 @@ double TFCS1DFunctionRegression::regression_value(double uniform) const
 
   if (n_neurons > 0) {
     int fLayers = 3;
-    vector<int> fLayerSize;
-    fLayerSize.push_back(2);
-    fLayerSize.push_back(n_neurons + 1);
-    fLayerSize.push_back(1);
+    vector<int> fLayerSize = {2, n_neurons + 1, 1};
 
     vector<vector<double>> fWeights;
-    for (int l = 0; l < fLayers; l++) {
-      vector<double> thisvector;
-      thisvector.reserve(fLayerSize[l]);
-      for (int i = 0; i < fLayerSize[l]; i++)
-        thisvector.push_back(0);  // placeholder
-      fWeights.push_back(thisvector);
+    for (int sz : fLayerSize) {
+      fWeights.emplace_back(sz, 0);  // placeholder
     }
-
-    for (int l = 0; l < fLayers; l++)
-      for (int i = 0; i < fLayerSize[l]; i++)
-        fWeights[l][i] = 0;
 
     for (int l = 0; l < fLayers - 1; l++)
       fWeights[l][fLayerSize[l] - 1] = 1;

--- a/source/Core/TFCS2DFunction.cxx
+++ b/source/Core/TFCS2DFunction.cxx
@@ -3,6 +3,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS2DFunction.h"
@@ -41,7 +42,7 @@ double TFCS2DFunction::CheckAndIntegrate2DHistogram(
       if (binval < 0) {
         // Can't work if a bin is negative, forcing bins to 0 in this case
         double fraction = binval / hint;
-        if (TMath::Abs(fraction) > 1e-5) {
+        if (std::abs(fraction) > 1e-5) {
           FCS_MSG_NOCLASS(logger,
                           "Warning: bin content is negative in histogram "
                               << hist->GetName() << " : " << hist->GetTitle()

--- a/source/Core/TFCSBinnedShower.cxx
+++ b/source/Core/TFCSBinnedShower.cxx
@@ -42,8 +42,8 @@ TFCSBinnedShower::~TFCSBinnedShower() {}
 void TFCSBinnedShower::set_layer_energy(
     long unsigned int event_index,
     long unsigned int layer_index,
-    const std::vector<unsigned int> bin_index_vector,
-    const std::vector<float> E_vector)
+    const std::vector<unsigned int>& bin_index_vector,
+    const std::vector<float>& E_vector)
 {
   // Assert that the event index is valid
   if (event_index >= m_eventlibrary.size()) {
@@ -62,10 +62,10 @@ void TFCSBinnedShower::set_layer_energy(
 }
 
 void TFCSBinnedShower::set_bin_boundaries(long unsigned int layer_index,
-                                          std::vector<float> R_lower,
-                                          std::vector<float> R_size,
-                                          std::vector<float> alpha_lower,
-                                          std::vector<float> alpha_size)
+                                          const std::vector<float>& R_lower,
+                                          const std::vector<float>& R_size,
+                                          const std::vector<float>& alpha_lower,
+                                          const std::vector<float>& alpha_size)
 {
   if (layer_index >= m_coordinates.size()) {
     m_coordinates.resize(layer_index + 1);
@@ -275,11 +275,12 @@ void TFCSBinnedShower::compute_n_hits_and_elayer(
   }
   // Store the hits per layer vector
   std::vector<std::vector<long unsigned int>>* hits_per_layer_ptr =
-      new std::vector<std::vector<long unsigned int>>(hits_per_layer);
+      new std::vector<std::vector<long unsigned int>>(
+          std::move(hits_per_layer));
   simulstate.setAuxInfo<void*>("BSNHits"_FCShash, hits_per_layer_ptr);
 
   // Store the energy per layer
-  std::vector<float>* elayer_ptr = new std::vector<float>(elayer);
+  std::vector<float>* elayer_ptr = new std::vector<float>(std::move(elayer));
   simulstate.setAuxInfo<void*>("BSELayer"_FCShash, elayer_ptr);
 }
 
@@ -708,16 +709,16 @@ void TFCSBinnedShower::load_bin_boundaries(const std::string& filename,
     auto& event_bins = m_coordinates.at(layer_index);
     switch (i) {
       case 0:
-        event_bins.R_lower = data;
+        event_bins.R_lower = std::move(data);
         break;
       case 1:
-        event_bins.R_size = data;
+        event_bins.R_size = std::move(data);
         break;
       case 2:
-        event_bins.alpha_lower = data;
+        event_bins.alpha_lower = std::move(data);
         break;
       case 3:
-        event_bins.alpha_size = data;
+        event_bins.alpha_size = std::move(data);
         break;
     }
   }
@@ -872,6 +873,6 @@ void TFCSBinnedShower::load_sub_bin_distribution(const std::string& filename)
     }
   }
 
-  m_upscaling_energies = energies;
-  m_sub_bin_distribution = data;
+  m_upscaling_energies = std::move(energies);
+  m_sub_bin_distribution = std::move(data);
 }

--- a/source/Core/TFCSBinnedShowerBase.cxx
+++ b/source/Core/TFCSBinnedShowerBase.cxx
@@ -91,11 +91,8 @@ FCSReturnCode TFCSBinnedShowerBase::simulate_hit(
     Hit& hit,
     TFCSSimulationState& simulstate,
     const TFCSTruthState* truth,
-    const TFCSExtrapolationState* extrapol)
+    const TFCSExtrapolationState* /*extrapol*/)
 {
-  // Extrapol unused, but needed for the interface
-  (void)extrapol;
-
   const int pdgId = truth->pdgid();
   const float charge = ParticleData::charge(pdgId);
   long unsigned int layer_index = calosample();
@@ -125,8 +122,8 @@ FCSReturnCode TFCSBinnedShowerBase::simulate_hit(
   // NOTE: this is ATLAS dependent
   // layer 21 is FCAL0
   if (layer_index <= 21) {
-    float delta_eta_mm = r * cos(alpha);
-    float delta_phi_mm = r * sin(alpha);
+    float delta_eta_mm = r * std::cos(alpha);
+    float delta_phi_mm = r * std::sin(alpha);
 
     // Particles with negative eta are expected to have the same shape
     // as those with positive eta after transformation: delta_eta -->
@@ -152,8 +149,8 @@ FCSReturnCode TFCSBinnedShowerBase::simulate_hit(
                                 << " layer " << layer_index);
 
   } else {  // FCAL is in (x,y,z)
-    const float hit_r = r * cos(alpha) + center_r;
-    float delta_phi = r * sin(alpha) / center_r;
+    const float hit_r = r * std::cos(alpha) + center_r;
+    float delta_phi = r * std::sin(alpha) / center_r;
     // We derive the shower shapes for electrons and positively charged
     // hadrons. Particle with the opposite charge are expected to have the
     // same shower shape after the transformation: delta_phi -->
@@ -161,8 +158,8 @@ FCSReturnCode TFCSBinnedShowerBase::simulate_hit(
     if ((charge < 0. && pdgId != 11) || pdgId == -11)
       delta_phi = -delta_phi;
     const float hit_phi = TVector2::Phi_mpi_pi(center_phi + delta_phi);
-    hit.set_eta_x(hit_r * cos(hit_phi));
-    hit.set_phi_y(hit_r * sin(hit_phi));
+    hit.set_eta_x(hit_r * std::cos(hit_phi));
+    hit.set_phi_y(hit_r * std::sin(hit_phi));
     hit.set_z(center_z);
 
     FCS_MSG_VERBOSE(" Hit x " << hit.x() << " y " << hit.y() << " layer "

--- a/source/Core/TFCSBinnedShowerONNX.cxx
+++ b/source/Core/TFCSBinnedShowerONNX.cxx
@@ -156,16 +156,16 @@ void TFCSBinnedShowerONNX::load_bin_boundaries(const std::string& filename,
     auto& event_bins = m_coordinates.at(layer_index);
     switch (i) {
       case 0:
-        event_bins.R_lower = data;
+        event_bins.R_lower = std::move(data);
         break;
       case 1:
-        event_bins.R_size = data;
+        event_bins.R_size = std::move(data);
         break;
       case 2:
-        event_bins.alpha_lower = data;
+        event_bins.alpha_lower = std::move(data);
         break;
       case 3:
-        event_bins.alpha_size = data;
+        event_bins.alpha_size = std::move(data);
         break;
     }
   }
@@ -184,11 +184,12 @@ void TFCSBinnedShowerONNX::Streamer(TBuffer& R__b)
   }
 }
 
-void TFCSBinnedShowerONNX::set_bin_boundaries(long unsigned int layer_index,
-                                              std::vector<float> R_lower,
-                                              std::vector<float> R_size,
-                                              std::vector<float> alpha_lower,
-                                              std::vector<float> alpha_size)
+void TFCSBinnedShowerONNX::set_bin_boundaries(
+    long unsigned int layer_index,
+    const std::vector<float>& R_lower,
+    const std::vector<float>& R_size,
+    const std::vector<float>& alpha_lower,
+    const std::vector<float>& alpha_size)
 {
   if (layer_index >= m_coordinates.size()) {
     m_coordinates.resize(layer_index + 1);
@@ -244,11 +245,12 @@ void TFCSBinnedShowerONNX::compute_n_hits_and_elayer(
   }
   // Store the hits per layer vector
   std::vector<std::vector<long unsigned int>>* hits_per_layer_ptr =
-      new std::vector<std::vector<long unsigned int>>(hits_per_layer);
+      new std::vector<std::vector<long unsigned int>>(
+          std::move(hits_per_layer));
   simulstate.setAuxInfo<void*>("BSNHits"_FCShash, hits_per_layer_ptr);
 
   // Store the energy per layer
-  std::vector<float>* elayer_ptr = new std::vector<float>(elayer);
+  std::vector<float>* elayer_ptr = new std::vector<float>(std::move(elayer));
   simulstate.setAuxInfo<void*>("BSELayer"_FCShash, elayer_ptr);
 }
 
@@ -537,7 +539,8 @@ void TFCSBinnedShowerONNX::load_sub_bin_distribution(
   m_use_upscaling = true;
   TFile* file = TFile::Open(filename.c_str(), "READ");
   if (!file || file->IsZombie()) {
-    std::cerr << "Failed to open file: " << filename << std::endl;
+    FCS_MSG_ERROR("Failed to open file: " << filename);
+    delete file;
     return;
   }
 
@@ -600,6 +603,6 @@ void TFCSBinnedShowerONNX::load_sub_bin_distribution(
     }
   }
 
-  m_upscaling_energies = energies;
-  m_sub_bin_distribution = data;
+  m_upscaling_energies = std::move(energies);
+  m_sub_bin_distribution = std::move(data);
 }

--- a/source/Core/TFCSEnergyAndHitGANV2.cxx
+++ b/source/Core/TFCSEnergyAndHitGANV2.cxx
@@ -139,7 +139,10 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
     return false;
   }
 
-  const TFCSGANEtaSlice::NetworkOutputs& outputs =
+  // Protect the GAN inference and network outputs when the same
+  // parametrization object is shared between threads (see ATLASSIM-7031)
+  std::scoped_lock lock(m_mutex);
+  TFCSGANEtaSlice::NetworkOutputs outputs =
       m_slice->GetNetworkOutputs(truth, extrapol, simulstate);
   FCS_MSG_VERBOSE("network outputs size: " << outputs.size());
 
@@ -151,7 +154,7 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
   FCS_MSG_DEBUG("energy voxels size = " << outputs.size());
 
   double totalEnergy = 0;
-  for (auto output : outputs) {
+  for (const auto& output : outputs) {
     totalEnergy += output.second;
   }
   if (totalEnergy < 0) {
@@ -164,13 +167,15 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
   simulstate.set_E(0);
 
   int vox = 0;
-  for (const auto& element : binsInLayers) {
-    const int layer = element.first;
-    const TH2D* h = &element.second;
+  for (const auto& [layer, h] : binsInLayers) {
+    if (h.IsZombie()) {
+      FCS_MSG_ERROR("Histogram for layer " << layer << " is broken");
+      return false;
+    }
 
-    const int xBinNum = h->GetNbinsX();
-    const int yBinNum = h->GetNbinsY();
-    const TAxis* x = h->GetXaxis();
+    const int xBinNum = h.GetNbinsX();
+    const int yBinNum = h.GetNbinsY();
+    const TAxis* x = h.GetXaxis();
 
     // If only one bin in r means layer is empty, no value should be added
     if (xBinNum == 1) {
@@ -214,13 +219,11 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
   }
 
   vox = 0;
-  for (const auto& element : binsInLayers) {
-    const int layer = element.first;
-    const TH2D* h = &element.second;
-    const int xBinNum = h->GetNbinsX();
-    const int yBinNum = h->GetNbinsY();
-    const TAxis* x = h->GetXaxis();
-    const TAxis* y = h->GetYaxis();
+  for (const auto& [layer, h] : binsInLayers) {
+    const int xBinNum = h.GetNbinsX();
+    const int yBinNum = h.GetNbinsY();
+    const TAxis* x = h.GetXaxis();
+    const TAxis* y = h.GetYaxis();
 
     simulstate.setAuxInfo<int>("GANlayer"_FCShash, layer);
     TFCSLateralShapeParametrizationHitBase::Hit hit;
@@ -251,7 +254,8 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
                   TFCSLateralShapeParametrizationHitBase::Class()))
           {
             TFCSLateralShapeParametrizationHitBase* sim =
-                (TFCSLateralShapeParametrizationHitBase*)(chain()[ichain]);
+                static_cast<TFCSLateralShapeParametrizationHitBase*>(
+                    chain()[ichain]);
             if (sim->simulate_hit(hit, simulstate, truth, extrapol)
                 != FCSSuccess)
             {
@@ -296,8 +300,8 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
     const float eta_jakobi = TMath::Abs(2.0 * TMath::Exp(-center_eta)
                                         / (1.0 + TMath::Exp(-2 * center_eta)));
 
-    int nHitsAlpha;
-    int nHitsR;
+    int nHitsAlpha {};
+    int nHitsR {};
 
     // Now create hits
     for (int ix = 1; ix <= xBinNum; ++ix) {
@@ -317,13 +321,13 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
           continue;
         }
 
-        if (fabs(pdgId) == 22 || fabs(pdgId) == 11) {
+        if (std::abs(pdgId) == 22 || std::abs(pdgId) == 11) {
           // maximum 10 MeV per hit, equally distributed in alpha and r
           int maxHitsInVoxel = energyInVoxel * truth->Ekin() / 10;
           if (maxHitsInVoxel < 1)
             maxHitsInVoxel = 1;
-          nHitsAlpha = sqrt(maxHitsInVoxel);
-          nHitsR = sqrt(maxHitsInVoxel);
+          nHitsAlpha = std::sqrt(maxHitsInVoxel);
+          nHitsR = std::sqrt(maxHitsInVoxel);
         } else {
           // One hit per mm along r
           nHitsR = x->GetBinUpEdge(ix) - x->GetBinLowEdge(ix);
@@ -334,7 +338,6 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
           } else {
             // d = 2*r*sin (a/2r) this distance at the upper r must be 1mm for
             // layer 1 or 5, 5mm otherwise.
-            const TAxis* y = h->GetYaxis();
             const double angle = y->GetBinUpEdge(iy) - y->GetBinLowEdge(iy);
             const double r = x->GetBinUpEdge(ix);
             const double d = 2 * r * sin(angle / 2 * r);
@@ -473,8 +476,8 @@ bool TFCSEnergyAndHitGANV2::fillEnergy(
                           TFCSLateralShapeParametrizationHitBase::Class()))
                   {
                     TFCSLateralShapeParametrizationHitBase* sim =
-                        (TFCSLateralShapeParametrizationHitBase*)(chain()
-                                                                      [ichain]);
+                        static_cast<TFCSLateralShapeParametrizationHitBase*>(
+                            chain()[ichain]);
                     if (sim->simulate_hit(hit, simulstate, truth, extrapol)
                         != FCSSuccess)
                     {
@@ -584,7 +587,7 @@ void TFCSEnergyAndHitGANV2::Print(Option_t* option) const
   }
 }
 
-int TFCSEnergyAndHitGANV2::GetBinsInFours(double const& bins)
+int TFCSEnergyAndHitGANV2::GetBinsInFours(double const bins)
 {
   if (bins < 4)
     return 4;
@@ -605,7 +608,7 @@ int TFCSEnergyAndHitGANV2::GetAlphaBinsForRBin(const TAxis* x,
     FCS_MSG_DEBUG("yBinNum is special value 32");
     const double widthX = x->GetBinWidth(ix);
     const double radious = x->GetBinCenter(ix);
-    double circumference = radious * 2 * TMath::Pi();
+    double circumference = radious * 2. * TMath::Pi();
     if (m_param.IsSymmetrisedAlpha()) {
       circumference = radious * TMath::Pi();
     }

--- a/source/Core/TFCSEnergyBinParametrization.cxx
+++ b/source/Core/TFCSEnergyBinParametrization.cxx
@@ -1,5 +1,8 @@
 // Copyright (c) 2024 CERN for the benefit of the FastCaloSim project
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+
 #include "FastCaloSim/Core/TFCSEnergyBinParametrization.h"
 
 #include "CLHEP/Random/RandFlat.h"
@@ -82,6 +85,12 @@ void TFCSEnergyBinParametrization::set_pdgid_Ekin_bin_probability(
   float ptot = 0;
   for (int iEbin = 0; iEbin <= n_bins(); ++iEbin)
     ptot += prob[iEbin];
+  if (ptot == 0.f) {
+    FCS_MSG_ERROR(
+        "TFCSEnergyBinParametrization::set_pdgid_Ekin_bin_probability(): "
+        "ptot is zero.");
+    return;
+  }
   float p = 0;
   for (int iEbin = 0; iEbin <= n_bins(); ++iEbin) {
     p += prob[iEbin] / ptot;
@@ -128,6 +137,12 @@ bool TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_probability_from_file(
   float ptot {};
   for (int iEbin = 0; iEbin <= n_bins(); ++iEbin)
     ptot += prob[iEbin];
+  if (ptot == 0.f) {
+    FCS_MSG_ERROR(
+        "TFCSEnergyBinParametrization::load_pdgid_Ekin_bin_probability_from_"
+        "file(): ptot is zero");
+    return false;
+  }
   float p {};
   for (int iEbin = 0; iEbin <= n_bins(); ++iEbin) {
     p += prob[iEbin] / ptot;
@@ -224,3 +239,5 @@ FCSReturnCode TFCSEnergyBinParametrization::simulate(
 
   return FCSSuccess;
 }
+
+#pragma GCC diagnostic pop

--- a/source/Core/TFCSGANEtaSlice.cxx
+++ b/source/Core/TFCSGANEtaSlice.cxx
@@ -105,7 +105,7 @@ bool TFCSGANEtaSlice::LoadGAN()
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_High12.*";
     FCS_MSG_DEBUG("Gan input file name " << inputFileName);
-    m_net_high = TFCSNetworkFactory::create(inputFileName);
+    m_net_high = TFCSNetworkFactory::create(std::move(inputFileName));
     if (m_net_high == nullptr)
       success = false;
 
@@ -137,9 +137,13 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
 
     std::string histoName = "r" + std::to_string(layer) + "w";
     TH1D* h1 = (TH1D*)file->Get(histoName.c_str());
-    if (std::isnan(h1->Integral())) {
+    if (!h1 || std::isnan(h1->Integral())) {
       histoName = "r" + std::to_string(layer);
       h1 = (TH1D*)file->Get(histoName.c_str());
+    }
+    if (!h1) {
+      throw std::runtime_error("Failed to load histogram " + histoName
+                               + " from ROOT file: " + rootFileName);
     }
 
     TAxis* x = (TAxis*)h2->GetXaxis();

--- a/source/Core/TFCSGANEtaSlice.cxx
+++ b/source/Core/TFCSGANEtaSlice.cxx
@@ -6,9 +6,9 @@
 
 // class header include
 #include <cmath>
-#include <fstream>
 #include <iostream>
-#include <sstream>
+#include <memory>
+#include <stdexcept>
 #include <string>
 
 #include "FastCaloSim/Core/TFCSGANEtaSlice.h"
@@ -18,7 +18,6 @@
 #include "TFile.h"
 #include "TFitResult.h"
 #include "TH1D.h"
-#include "TMath.h"
 #include "TTree.h"
 
 TFCSGANEtaSlice::TFCSGANEtaSlice() {}
@@ -90,7 +89,7 @@ bool TFCSGANEtaSlice::LoadGAN()
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_All.*";
     FCS_MSG_DEBUG("Gan input file name " << inputFileName);
-    m_net_all = TFCSNetworkFactory::create(inputFileName);
+    m_net_all = TFCSNetworkFactory::create(std::move(inputFileName));
     if (m_net_all == nullptr)
       success = false;
   } else if (m_pid == 2212) {
@@ -98,7 +97,7 @@ bool TFCSGANEtaSlice::LoadGAN()
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_High10.*";
     FCS_MSG_DEBUG("Gan input file name " << inputFileName);
-    m_net_all = TFCSNetworkFactory::create(inputFileName);
+    m_net_all = TFCSNetworkFactory::create(std::move(inputFileName));
     if (m_net_all == nullptr)
       success = false;
   } else {
@@ -113,7 +112,7 @@ bool TFCSGANEtaSlice::LoadGAN()
     inputFileName = m_param.GetInputFolder() + "/neural_net_"
         + std::to_string(m_pid) + "_eta_" + std::to_string(m_etaMin) + "_"
         + std::to_string(m_etaMax) + "_UltraLow12.*";
-    m_net_low = TFCSNetworkFactory::create(inputFileName);
+    m_net_low = TFCSNetworkFactory::create(std::move(inputFileName));
     if (m_net_low == nullptr)
       success = false;
   }
@@ -126,7 +125,11 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
       + std::to_string(m_pid) + "_E1048576_eta_" + std::to_string(m_etaMin)
       + "_" + std::to_string(m_etaMin + 5) + ".root";
   FCS_MSG_DEBUG("Opening file " << rootFileName);
-  TFile* file = TFile::Open(rootFileName.c_str(), "read");
+  std::unique_ptr<TFile> file(TFile::Open(rootFileName.c_str(), "read"));
+  if (!file || file->IsZombie()) {
+    throw std::runtime_error("Failed to open or initialize ROOT file: "
+                             + rootFileName);
+  }
   for (int layer : m_param.GetRelevantLayers()) {
     FCS_MSG_DEBUG("Layer " << layer);
     TFCSGANXMLParameters::Binning binsInLayers = m_param.GetBinning();
@@ -134,7 +137,7 @@ void TFCSGANEtaSlice::CalculateMeanPointFromDistributionOfR()
 
     std::string histoName = "r" + std::to_string(layer) + "w";
     TH1D* h1 = (TH1D*)file->Get(histoName.c_str());
-    if (TMath::IsNaN(h1->Integral())) {
+    if (std::isnan(h1->Integral())) {
       histoName = "r" + std::to_string(layer);
       h1 = (TH1D*)file->Get(histoName.c_str());
     }
@@ -165,7 +168,11 @@ void TFCSGANEtaSlice::ExtractExtrapolatorMeansFromInputs()
       + std::to_string(m_pid) + "_E65536_eta_" + std::to_string(m_etaMin) + "_"
       + std::to_string(m_etaMin + 5) + "_validation.root";
   FCS_MSG_DEBUG("Opening file " << rootFileName);
-  TFile* file = TFile::Open(rootFileName.c_str(), "read");
+  std::unique_ptr<TFile> file(TFile::Open(rootFileName.c_str(), "read"));
+  if (!file || file->IsZombie()) {
+    throw std::runtime_error("Failed to open or initialize ROOT file: "
+                             + rootFileName);
+  }
   for (int layer : m_param.GetRelevantLayers()) {
     std::string branchName = "extrapWeight_" + std::to_string(layer);
     TH1D* h = new TH1D("h", "h", 100, 0.01, 1);
@@ -181,13 +188,13 @@ void TFCSGANEtaSlice::ExtractExtrapolatorMeansFromInputs()
 VNetworkBase::NetworkOutputs TFCSGANEtaSlice::GetNetworkOutputs(
     const TFCSTruthState* truth,
     const TFCSExtrapolationState* extrapol,
-    TFCSSimulationState simulstate) const
+    TFCSSimulationState& simulstate) const
 {
   double randUniformZ = 0.;
   NetworkInputs inputs;
 
   int maxExp = 0, minExp = 0;
-  if (m_pid == 22 || fabs(m_pid) == 11) {
+  if (m_pid == 22 || std::abs(m_pid) == 11) {
     if (truth->P() > 4096)
     {  // This is the momentum, not the energy, because the split is
        // based on the samples which are produced with the momentum
@@ -197,10 +204,10 @@ VNetworkBase::NetworkOutputs TFCSGANEtaSlice::GetNetworkOutputs(
       maxExp = 12;
       minExp = 6;
     }
-  } else if (fabs(m_pid) == 211) {
+  } else if (std::abs(m_pid) == 211) {
     maxExp = 22;
     minExp = 8;
-  } else if (fabs(m_pid) == 2212) {
+  } else if (std::abs(m_pid) == 2212) {
     maxExp = 22;
     minExp = 10;
   }
@@ -236,7 +243,7 @@ VNetworkBase::NetworkOutputs TFCSGANEtaSlice::GetNetworkOutputs(
                   // regions and added only to the GANs that use it, for now all
                   // GANs have 3 conditioning inputs so filling zeros
       inputs["mycond"].insert(std::pair<std::string, double>(
-          "variable_1", fabs(extrapol->IDCaloBoundary_eta())));
+          "variable_1", std::abs(extrapol->IDCaloBoundary_eta())));
     } else {
       inputs["mycond"].insert(std::pair<std::string, double>("variable_1", 0));
     }

--- a/source/Core/TFCSGANLWTNNHandler.cxx
+++ b/source/Core/TFCSGANLWTNNHandler.cxx
@@ -47,7 +47,7 @@ void TFCSGANLWTNNHandler::setupNet()
   m_lwtnn_graph = std::make_unique<lwt::LightweightGraph>(config);
   // Get the output layers
   FCS_MSG_VERBOSE("Getting output layers for neural network");
-  for (auto node : config.outputs) {
+  for (const auto& node : config.outputs) {
     const std::string node_name = node.first;
     const lwt::OutputNodeConfig node_config = node.second;
     for (const std::string& label : node_config.labels) {

--- a/source/Core/TFCSGANXMLParameters.cxx
+++ b/source/Core/TFCSGANXMLParameters.cxx
@@ -5,16 +5,39 @@
 ///////////////////////////////////////////////////////////////////
 
 // class header include
+#include <cmath>
 #include <iostream>
 #include <sstream>
 
 #include "FastCaloSim/Core/TFCSGANXMLParameters.h"
 
+#include <libxml/parser.h>
+
 #include "TMath.h"
 
-TFCSGANXMLParameters::TFCSGANXMLParameters() {}
+namespace
+{
+// Read an XML attribute and free the memory allocated by xmlGetProp
+std::string getXmlAttr(xmlNodePtr node, const char* name)
+{
+  xmlChar* prop = xmlGetProp(node, BAD_CAST name);
+  if (!prop)
+    return {};
+  std::string value(reinterpret_cast<const char*>(prop));
+  xmlFree(prop);
+  return value;
+}
 
-TFCSGANXMLParameters::~TFCSGANXMLParameters() {}
+int getXmlAttrInt(xmlNodePtr node, const char* name)
+{
+  const std::string attribute = getXmlAttr(node, name);
+  return attribute.empty() ? 0 : std::stoi(attribute);
+}
+}  // namespace
+
+TFCSGANXMLParameters::TFCSGANXMLParameters() = default;
+
+TFCSGANXMLParameters::~TFCSGANXMLParameters() = default;
 
 void TFCSGANXMLParameters::InitialiseFromXML(
     int pid, int etaMid, const std::string& FastCaloGANInputFolderName)
@@ -23,6 +46,11 @@ void TFCSGANXMLParameters::InitialiseFromXML(
   std::string xmlFullFileName = FastCaloGANInputFolderName + "/binning.xml";
 
   xmlDocPtr doc = xmlParseFile(xmlFullFileName.c_str());
+  if (!doc) {
+    FCS_MSG_WARNING("Failed to parse XML file: " << xmlFullFileName);
+    return;
+  }
+
   for (xmlNodePtr nodeRoot = doc->children; nodeRoot != nullptr;
        nodeRoot = nodeRoot->next)
   {
@@ -32,27 +60,25 @@ void TFCSGANXMLParameters::InitialiseFromXML(
            nodeParticle = nodeParticle->next)
       {
         if (xmlStrEqual(nodeParticle->name, BAD_CAST "Particle")) {
-          int nodePid =
-              atof((const char*)xmlGetProp(nodeParticle, BAD_CAST "pid"));
-          for (xmlNodePtr nodeBin = nodeParticle->children; nodeBin != nullptr;
-               nodeBin = nodeBin->next)
-          {
-            if (nodePid == pid) {
-              if (xmlStrEqual(nodeBin->name, BAD_CAST "Bin")) {
-                int nodeEtaMin =
-                    atof((const char*)xmlGetProp(nodeBin, BAD_CAST "etaMin"));
-                int nodeEtaMax =
-                    atof((const char*)xmlGetProp(nodeBin, BAD_CAST "etaMax"));
-                int regionId =
-                    atof((const char*)xmlGetProp(nodeBin, BAD_CAST "regionId"));
+          int nodePid = getXmlAttrInt(nodeParticle, "pid");
 
-                if (fabs(etaMid) > nodeEtaMin && fabs(etaMid) < nodeEtaMax) {
+          if (nodePid == pid) {
+            for (xmlNodePtr nodeBin = nodeParticle->children;
+                 nodeBin != nullptr;
+                 nodeBin = nodeBin->next)
+            {
+              if (xmlStrEqual(nodeBin->name, BAD_CAST "Bin")) {
+                int nodeEtaMin = getXmlAttrInt(nodeBin, "etaMin");
+                int nodeEtaMax = getXmlAttrInt(nodeBin, "etaMax");
+                int regionId = getXmlAttrInt(nodeBin, "regionId");
+
+                if (std::abs(etaMid) > nodeEtaMin
+                    && std::abs(etaMid) < nodeEtaMax)
+                {
                   m_symmetrisedAlpha =
                       ReadBooleanAttribute("symmetriseAlpha", nodeParticle);
-                  m_ganVersion = atof(
-                      (const char*)xmlGetProp(nodeBin, BAD_CAST "ganVersion"));
-                  m_latentDim = atof((const char*)xmlGetProp(
-                      nodeParticle, BAD_CAST "latentDim"));
+                  m_ganVersion = getXmlAttrInt(nodeBin, "ganVersion");
+                  m_latentDim = getXmlAttrInt(nodeParticle, "latentDim");
 
                   for (xmlNodePtr nodeLayer = nodeBin->children;
                        nodeLayer != nullptr;
@@ -60,40 +86,49 @@ void TFCSGANXMLParameters::InitialiseFromXML(
                   {
                     if (xmlStrEqual(nodeLayer->name, BAD_CAST "Layer")) {
                       std::vector<double> edges;
-                      std::string s((const char*)xmlGetProp(
-                          nodeLayer, BAD_CAST "r_edges"));
+                      std::string s(getXmlAttr(nodeLayer, "r_edges"));
 
                       std::istringstream ss(s);
                       std::string token;
 
                       while (std::getline(ss, token, ',')) {
-                        edges.push_back(atof(token.c_str()));
+                        edges.push_back(std::stod(token));
                       }
 
-                      int binsInAlpha = atof((const char*)xmlGetProp(
-                          nodeLayer, BAD_CAST "n_bin_alpha"));
-                      int layer = atof(
-                          (const char*)xmlGetProp(nodeLayer, BAD_CAST "id"));
+                      int binsInAlpha = getXmlAttrInt(nodeLayer, "n_bin_alpha");
+                      int layer = getXmlAttrInt(nodeLayer, "id");
 
                       std::string name = "hist_pid_" + std::to_string(nodePid)
                           + "_region_" + std::to_string(regionId) + "_layer_"
                           + std::to_string(layer);
-                      int xBins = edges.size() - 1;
-                      if (xBins == 0)
-                        xBins = 1;  // remove warning
-                      else
+                      int xBins = static_cast<int>(edges.size()) - 1;
+                      if (xBins <= 0) {
+                        FCS_MSG_DEBUG(
+                            "No bins defined in r for layer "
+                            << layer
+                            << ", setting to 1 bin to avoid empty histogram");
+                        xBins = 1;
+                        if (edges.empty())
+                          edges.push_back(0);
+                        edges.push_back(edges.back() + 1);
+                      } else {
                         m_relevantlayers.push_back(layer);
+                      }
                       double minAlpha = -TMath::Pi();
                       if (m_symmetrisedAlpha && binsInAlpha > 1) {
                         minAlpha = 0;
                       }
-                      m_binning[layer] = TH2D(name.c_str(),
-                                              name.c_str(),
-                                              xBins,
-                                              &edges[0],
-                                              binsInAlpha,
-                                              minAlpha,
-                                              TMath::Pi());
+                      auto& h = m_binning[layer] = TH2D(name.c_str(),
+                                                        name.c_str(),
+                                                        xBins,
+                                                        edges.data(),
+                                                        binsInAlpha,
+                                                        minAlpha,
+                                                        TMath::Pi());
+                      // Detach from any ROOT directory: the histogram is
+                      // owned by this object and must not be registered in
+                      // the (thread-unsafe) global directory
+                      h.SetDirectory(nullptr);
                     }
                   }
                 }
@@ -110,9 +145,7 @@ void TFCSGANXMLParameters::InitialiseFromXML(
 bool TFCSGANXMLParameters::ReadBooleanAttribute(const std::string& name,
                                                 xmlNodePtr node)
 {
-  std::string attribute = (const char*)xmlGetProp(node, BAD_CAST name.c_str());
-  bool value = attribute == "true" ? true : false;
-  return value;
+  return getXmlAttr(node, name.c_str()) == "true";
 }
 
 void TFCSGANXMLParameters::Print() const
@@ -122,17 +155,23 @@ void TFCSGANXMLParameters::Print() const
   FCS_MSG_INFO("  ganVersion:" << m_ganVersion);
   FCS_MSG_INFO("  latentDim: " << m_latentDim);
   FCS_MSG(INFO) << "  relevantlayers: ";
-  for (auto l : m_relevantlayers) {
+  for (const auto& l : m_relevantlayers) {
     FCS_MSG(INFO) << l << " ";
   }
   FCS_MSG(INFO) << END_FCS_MSG(INFO);
 
-  for (auto element : m_binning) {
+  for (const auto& element : m_binning) {
     int layer = element.first;
-    TH2D* h = &element.second;
+    const TH2D* h = &element.second;
+
+    if (h->IsZombie()) {
+      FCS_MSG_WARNING("Histogram for layer " << layer
+                                             << " is broken. Skipping.");
+      continue;
+    }
 
     int xBinNum = h->GetNbinsX();
-    TAxis* x = (TAxis*)h->GetXaxis();
+    const TAxis* x = h->GetXaxis();
 
     // If only one bin in r means layer is empty, no value should be added
     if (xBinNum == 1) {

--- a/source/Core/TFCSGANXMLParameters.cxx
+++ b/source/Core/TFCSGANXMLParameters.cxx
@@ -7,6 +7,7 @@
 // class header include
 #include <cmath>
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include "FastCaloSim/Core/TFCSGANXMLParameters.h"
@@ -45,7 +46,10 @@ void TFCSGANXMLParameters::InitialiseFromXML(
   m_fastCaloGANInputFolderName = FastCaloGANInputFolderName;
   std::string xmlFullFileName = FastCaloGANInputFolderName + "/binning.xml";
 
-  xmlDocPtr doc = xmlParseFile(xmlFullFileName.c_str());
+  // RAII ownership: the document must also be freed when the numeric
+  // attribute conversions below throw
+  const std::unique_ptr<xmlDoc, void (*)(xmlDocPtr)> doc(
+      xmlParseFile(xmlFullFileName.c_str()), xmlFreeDoc);
   if (!doc) {
     FCS_MSG_WARNING("Failed to parse XML file: " << xmlFullFileName);
     return;
@@ -92,6 +96,8 @@ void TFCSGANXMLParameters::InitialiseFromXML(
                       std::string token;
 
                       while (std::getline(ss, token, ',')) {
+                        if (token.empty())
+                          continue;
                         edges.push_back(std::stod(token));
                       }
 
@@ -139,7 +145,6 @@ void TFCSGANXMLParameters::InitialiseFromXML(
       }
     }
   }
-  xmlFreeDoc(doc);
 }
 
 bool TFCSGANXMLParameters::ReadBooleanAttribute(const std::string& name,

--- a/source/Core/TFCSHitCellMappingWiggle.cxx
+++ b/source/Core/TFCSHitCellMappingWiggle.cxx
@@ -28,17 +28,26 @@ TFCSHitCellMappingWiggle::TFCSHitCellMappingWiggle(const char* name,
 
 TFCSHitCellMappingWiggle::~TFCSHitCellMappingWiggle()
 {
-  for (const auto* function : m_functions)
-    delete function;
+  clear();
+}
+
+void TFCSHitCellMappingWiggle::clear()
+{
+  for (auto*& function : m_functions) {
+    if (function) {
+      delete function;
+      function = nullptr;
+    }
+  }
+  m_functions.clear();
+  m_bin_low_edge.clear();
 }
 
 void TFCSHitCellMappingWiggle::initialize(TFCS1DFunction* func)
 {
   if (!func)
     return;
-  for (const auto* function : m_functions)
-    if (function)
-      delete function;
+  clear();
 
   m_functions.resize(1);
   m_functions[0] = func;
@@ -58,9 +67,7 @@ void TFCSHitCellMappingWiggle::initialize(
                            << bin_low_edges.size() << "bins");
     return;
   }
-  for (const auto* function : m_functions)
-    if (function)
-      delete function;
+  clear();
   m_functions = functions;
   m_bin_low_edge = bin_low_edges;
 }

--- a/source/Core/TFCSMLCalorimeterSimulator.cxx
+++ b/source/Core/TFCSMLCalorimeterSimulator.cxx
@@ -9,7 +9,7 @@ TFCSMLCalorimeterSimulator::TFCSMLCalorimeterSimulator() {}
 
 TFCSMLCalorimeterSimulator::~TFCSMLCalorimeterSimulator() {}
 
-bool TFCSMLCalorimeterSimulator::loadSimulator(std::string filename)
+bool TFCSMLCalorimeterSimulator::loadSimulator(const std::string& filename)
 {
   // Load the simulator
   try {
@@ -52,16 +52,16 @@ VNetworkBase::NetworkOutputs TFCSMLCalorimeterSimulator::predictVoxels(
   VNetworkBase::NetworkInputs inputs;
 
   int i = 0;
-  for (float eta : eta_vector) {
-    inputs["inn_eta_in"].insert(
-        std::pair<std::string, double>("variable_" + std::to_string(i), eta));
+  for (float thisEta : eta_vector) {
+    inputs["inn_eta_in"].insert(std::pair<std::string, double>(
+        "variable_" + std::to_string(i), thisEta));
     i++;
   }
 
   i = 0;
-  for (float energy : energy_vector) {
+  for (float thisEnergy : energy_vector) {
     inputs["inn_einc_in"].insert(std::pair<std::string, double>(
-        "variable_" + std::to_string(i), energy));
+        "variable_" + std::to_string(i), thisEnergy));
     i++;
   }
 
@@ -190,16 +190,16 @@ VNetworkBase::NetworkOutputs TFCSMLCalorimeterSimulator::predictVoxels() const
   VNetworkBase::NetworkInputs inputs;
 
   int i = 0;
-  for (float eta : eta_vector) {
-    inputs["inn_eta_in"].insert(
-        std::pair<std::string, double>("variable_" + std::to_string(i), eta));
+  for (float thisEta : eta_vector) {
+    inputs["inn_eta_in"].insert(std::pair<std::string, double>(
+        "variable_" + std::to_string(i), thisEta));
     i++;
   }
 
   i = 0;
-  for (float energy : energy_vector) {
+  for (float thisEnergy : energy_vector) {
     inputs["inn_einc_in"].insert(std::pair<std::string, double>(
-        "variable_" + std::to_string(i), energy));
+        "variable_" + std::to_string(i), thisEnergy));
     i++;
   }
 

--- a/source/Core/TFCSNetworkFactory.cxx
+++ b/source/Core/TFCSNetworkFactory.cxx
@@ -130,7 +130,7 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(
     FCS_MSG_NOCLASS(
         logger,
         "No data in bytes, string contains data, " << "creating from string.");
-    return create(string_input);
+    return create(std::move(string_input));
   } else {
     throw std::invalid_argument(
         "Neither vector_input nor string_input contain data");
@@ -156,7 +156,7 @@ std::unique_ptr<VNetworkBase> TFCSNetworkFactory::create(
     FCS_MSG_NOCLASS(
         logger,
         "No data in bytes, string contains data, " << "creating from string.");
-    return create(string_input, graph_form);
+    return create(std::move(string_input), graph_form);
   } else {
     throw std::invalid_argument(
         "Neither vector_input nor string_input contain data");

--- a/source/Core/TFCSONNXHandler.cxx
+++ b/source/Core/TFCSONNXHandler.cxx
@@ -186,7 +186,7 @@ void TFCSONNXHandler::setupNet()
         dimension_of_node.push_back(node_dim);
       };
     };
-    m_inputNodeDims.push_back(dimension_of_node);
+    m_inputNodeDims.push_back(std::move(dimension_of_node));
   };
   FCS_MSG_DEBUG("Finished looping on inputs.");
 
@@ -243,7 +243,7 @@ void TFCSONNXHandler::setupNet()
         node_size *= node_dim;
       };
     };
-    m_outputNodeDims.push_back(dimension_of_node);
+    m_outputNodeDims.push_back(std::move(dimension_of_node));
     m_outputNodeSize.push_back(node_size);
 
     // The outputs are treated as a flat vector
@@ -252,7 +252,7 @@ void TFCSONNXHandler::setupNet()
       std::string layer_name =
           std::string(output_name) + "_" + std::to_string(part_n);
       FCS_MSG_VERBOSE("Found output layer named " << layer_name);
-      m_outputLayers.push_back(layer_name);
+      m_outputLayers.push_back(std::move(layer_name));
     }
   }
   FCS_MSG_DEBUG("Removing prefix from stored layers.");
@@ -389,7 +389,7 @@ VNetworkBase::NetworkOutputs TFCSONNXHandler::computeTemplate(
       elements_in_node *= dimension_len;
     };
     FCS_MSG_DEBUG("Elements in node " << elements_in_node);
-    for (auto inp : inputs) {
+    for (const auto& inp : inputs) {
       FCS_MSG_DEBUG("Have input named " << inp.first);
     };
     // Get the node content and remove any common prefix from the elements
@@ -399,7 +399,7 @@ VNetworkBase::NetworkOutputs TFCSONNXHandler::computeTemplate(
     FCS_MSG_DEBUG("Found node named " << node_name << " with "
                                       << elements_in_node << " elements.");
     // Then the rest should be numbers from 0 up
-    for (auto element : node_inputs) {
+    for (const auto& element : node_inputs) {
       first_digit = element.first.find_first_of("0123456789");
       // if there is no digit, it's not an element
       if (first_digit < element.first.length()) {
@@ -407,7 +407,7 @@ VNetworkBase::NetworkOutputs TFCSONNXHandler::computeTemplate(
         node_elements[key_number] = element.second;
       }
     }
-    input_values[node_n] = node_elements;
+    input_values[node_n] = std::move(node_elements);
 
     FCS_MSG_DEBUG("Creating ort tensor n_dimensions = "
                   << n_dimensions

--- a/source/Core/TFCSParametrizationBase.cxx
+++ b/source/Core/TFCSParametrizationBase.cxx
@@ -97,8 +97,15 @@ void TFCSParametrizationBase::FindDuplicates(FindDuplicateClasses_t& dupclasses)
       // If param is already in the duplication list, skip over
       auto checkexist = dup.find(param);
       if (checkexist != dup.end()) {
-        FCS_MSG_DEBUG("Found duplicate pointer for: " << param << "="
-                                                      << param->GetName());
+        FCS_MSG_WARNING(
+            " [TFCSParametrizationBase::FindDuplicates] "
+            "DUPLICATE POINTER DETECTED");
+        FCS_MSG_WARNING(" - Pointer           : " << param);
+        FCS_MSG_WARNING(" - Name              : " << param->GetName());
+        FCS_MSG_WARNING(" - Class             : " << param->ClassName());
+        FCS_MSG_WARNING(" - Occurs in parent  : " << this << " ("
+                                                  << this->ClassName() << ")"
+                                                  << " index=" << i);
         if (checkexist->second.replace) {
           TFCSParametrizationBase* refparam = checkexist->second.replace;
           FCS_MSG_DEBUG("Found duplicate pointer: "

--- a/source/Core/TFCSParametrizationChain.cxx
+++ b/source/Core/TFCSParametrizationChain.cxx
@@ -231,7 +231,7 @@ void TFCSParametrizationChain::Streamer(TBuffer& R__b)
       TObject* parent = R__b.GetParent();
       if (R__b.GetParent()) {
         if (parent->InheritsFrom(TDirectory::Class())) {
-          dir = (TDirectory*)parent;
+          dir = static_cast<TDirectory*>(parent);
         }
       }
 
@@ -280,7 +280,7 @@ void TFCSParametrizationChain::Streamer(TBuffer& R__b)
       TObject* parent = R__b.GetParent();
       if (R__b.GetParent()) {
         if (parent->InheritsFrom(TDirectory::Class())) {
-          dir = (TDirectory*)parent;
+          dir = static_cast<TDirectory*>(parent);
         }
       }
     }

--- a/source/Core/TFCSPhiModulationCorrection.cxx
+++ b/source/Core/TFCSPhiModulationCorrection.cxx
@@ -28,7 +28,7 @@ TFCSPhiModulationCorrection::TFCSPhiModulationCorrection(const char* name,
 TFCSPhiModulationCorrection::~TFCSPhiModulationCorrection() {}
 
 void TFCSPhiModulationCorrection::load_phi_modulation(
-    std::string filename,
+    const std::string& filename,
     long unsigned int layer_index,
     float eta_min,
     float eta_max,

--- a/source/Core/TFCSSimpleLWTNNHandler.cxx
+++ b/source/Core/TFCSSimpleLWTNNHandler.cxx
@@ -42,7 +42,7 @@ void TFCSSimpleLWTNNHandler::setupNet()
       config.inputs, config.layers, config.outputs);
   // Get the output layers
   FCS_MSG_DEBUG("Getting output layers for neural network");
-  for (std::string name : config.outputs) {
+  for (const std::string& name : config.outputs) {
     FCS_MSG_VERBOSE("Found output layer called " << name);
     m_outputLayers.push_back(name);
   };
@@ -69,7 +69,7 @@ TFCSSimpleLWTNNHandler::NetworkOutputs TFCSSimpleLWTNNHandler::compute(
                   << " An LWTNN neural network can only handle one node.");
   };
   std::map<std::string, double> flat_inputs;
-  for (auto node : inputs) {
+  for (const auto& node : inputs) {
     flat_inputs = node.second;
   }
   // Now we have flattened, we can compute.

--- a/source/Core/TFCSVoxelHistoLateralCovarianceFluctuations.cxx
+++ b/source/Core/TFCSVoxelHistoLateralCovarianceFluctuations.cxx
@@ -132,7 +132,7 @@ bool TFCSVoxelHistoLateralCovarianceFluctuations::initialize(
         transform[x][y] = func;
       }
     }
-    m_transform.push_back(transform);
+    m_transform.push_back(std::move(transform));
     ++bin;
   }
 

--- a/source/Core/VNetworkLWTNN.cxx
+++ b/source/Core/VNetworkLWTNN.cxx
@@ -60,7 +60,7 @@ void VNetworkLWTNN::fillJson(std::string const& tree_name)
     TTree* tree = (TTree*)tfile.Get(tree_name.c_str());
     std::string found = this->readStringFromTTree(*tree);
     FCS_MSG_DEBUG("Read json from root file, length " << found.length());
-    m_json = found;
+    m_json = std::move(found);
   } else {
     FCS_MSG_VERBOSE("Treating input file as a text json file");
     // The input file is read into a stringstream


### PR DESCRIPTION
Ports upstream Athena changes in preparation for full migration:

- Detach GAN binning histograms from gDirectory and guard GAN inference
  with a mutex (ATLASSIM-7031 thread-safety fixes)
- Fix libxml2 attribute leaks and add robustness to binning.xml parsing
- Fix memory leaks: histo_to_array, TFCSHitCellMappingWiggle
  re-initialization, TFile handling in TFCSGANEtaSlice/TFCSBinnedShowerONNX
- Initialize members: Hit::m_z, GAN/shape-parametrization headers,
  FCS_Cell structs, CylinderIntersections
- Guard against division by zero in TFCS1DFunction::get_maxdev and
  TFCSEnergyBinParametrization
- Modernize: std::abs/std::isnan over fabs/TMath, static_cast over
  C-style casts, const-ref getters/parameters, std::move on push_backs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in histogram, GAN, and simulation workflows by preventing divide-by-zero cases, adding safer file parsing/loading checks, and initializing previously uninitialized values.
  * Reduced the chance of runtime issues by tightening memory and ownership handling in several data-loading paths.

* **Refactor**
  * Streamlined several public interfaces to avoid unnecessary data copying, which should improve performance and responsiveness.
  * Added safer thread handling in energy processing and cleaned up internal state management across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->