### PR TITLE
Fix missing <cmath>/TMath.h includes for gcc15 + ROOT 6.40

### DIFF
--- a/include/FastCaloSim/Core/TFCS2DFunctionTemplateInterpolationExpHistogram.h
+++ b/include/FastCaloSim/Core/TFCS2DFunctionTemplateInterpolationExpHistogram.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS2DFunctionTemplateHistogram.h"
@@ -78,7 +79,7 @@ public:
     }
 
     if (dfrac > 0.0 && dfracprev > 0.0) {
-      ldfrac = log(dfrac / l) - log(dfracprev / lprev);
+      ldfrac = std::log(dfrac / l) - std::log(dfracprev / lprev);
     }
 
     Trandom dfracnext = 0.0;
@@ -92,7 +93,7 @@ public:
     }
 
     if (dfrac > 0.0 && dfracnext > 0.0) {
-      ldfracnext = log(dfracnext / lnext) - log(dfrac / l);
+      ldfracnext = std::log(dfracnext / lnext) - std::log(dfrac / l);
     }
 
     Trandom beta = 0.0, betaprev = 0.0, betanext = 0.0;

--- a/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitBase.h
+++ b/include/FastCaloSim/Core/TFCSLateralShapeParametrizationHitBase.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSLateralShapeParametrization.h"
 
 class TFCSLateralShapeParametrizationHitBase
@@ -114,9 +116,9 @@ public:
     inline auto r() const -> const auto
     {
       if (m_useXYZ)
-        return sqrt(m_eta_x * m_eta_x + m_phi_y * m_phi_y);
+        return std::sqrt(m_eta_x * m_eta_x + m_phi_y * m_phi_y);
       else
-        return m_z / sinh(m_eta_x);
+        return m_z / std::sinh(m_eta_x);
     }
     inline auto center_r() const -> const auto& { return m_center_r; }
     inline auto center_z() const -> const auto& { return m_center_z; }

--- a/include/FastCaloSim/Core/TFCSPhiModulationCorrection.h
+++ b/include/FastCaloSim/Core/TFCSPhiModulationCorrection.h
@@ -6,6 +6,7 @@
 #include "FastCaloSim/Core/TFCSLateralShapeParametrizationHitBase.h"
 
 // External includes
+#include <cmath>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/include/FastCaloSim/Geometry/MeanAndRMS.h
+++ b/include/FastCaloSim/Geometry/MeanAndRMS.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <math.h>
+#include <cmath>
 
 class MeanAndRMS
 {
@@ -61,21 +61,21 @@ public:
   {
     double r2 = rms2();
     if (r2 >= 0)
-      return sqrt(r2);
+      return std::sqrt(r2);
     else
       return 0;
   };
   double mean_error() const
   {
     if (m_w > 0)
-      return rms() / sqrt(m_w);
+      return rms() / std::sqrt(m_w);
     else
       return 0;
   };
   double rms_error() const
   {
     if (m_w > 0)
-      return rms() / sqrt(2 * m_w);
+      return rms() / std::sqrt(2 * m_w);
     else
       return 0;
   };

--- a/source/Core/TFCS1DFunctionHistogram.cxx
+++ b/source/Core/TFCS1DFunctionHistogram.cxx
@@ -3,6 +3,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS1DFunctionHistogram.h"
@@ -146,7 +147,7 @@ auto TFCS1DFunctionHistogram::get_maxdev(TH1* h_in, TH1D* h_out) -> double
   double maxdev = 0;
   for (int i = 1; i <= h_in->GetNbinsX(); i++) {
     int bin = h_out->FindBin(h_in->GetBinCenter(i));
-    double val = fabs(h_out->GetBinContent(bin) - h_in->GetBinContent(i));
+    double val = std::fabs(h_out->GetBinContent(bin) - h_in->GetBinContent(i));
     if (val > maxdev)
       maxdev = val;
   }
@@ -188,7 +189,7 @@ auto TFCS1DFunctionHistogram::smart_rebin(TH1D* h_input) -> TH1D*
     double nextBin = h_out1->GetBinContent(b + 1);
     double width = h_out1->GetBinWidth(b);
     double nextwidth = h_out1->GetBinWidth(b + 1);
-    double diff = fabs(nextBin - thisBin);
+    double diff = std::fabs(nextBin - thisBin);
     if (!skip && (diff > change || merged)) {
       binborder.push_back(h_out1->GetBinLowEdge(b + 1));
       content.push_back(thisBin);
@@ -258,9 +259,9 @@ auto TFCS1DFunctionHistogram::non_linear(
   if ((y2 - y1) < eps)
     x = x1;
   else {
-    double b = (x1 - x2) / (sqrt(y1) - sqrt(y2));
-    double a = x1 - b * sqrt(y1);
-    x = a + b * sqrt(y);
+    double b = (x1 - x2) / (std::sqrt(y1) - std::sqrt(y2));
+    double a = x1 - b * std::sqrt(y1);
+    x = a + b * std::sqrt(y);
   }
   return x;
 }

--- a/source/Core/TFCS1DFunctionInt16Histogram.cxx
+++ b/source/Core/TFCS1DFunctionInt16Histogram.cxx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS1DFunctionInt16Histogram.h"
@@ -29,7 +30,7 @@ void TFCS1DFunctionInt16Histogram::Initialize(const TH1* hist)
     if (binval < 0) {
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
-      if (TMath::Abs(fraction) > 1e-5) {
+      if (std::abs(fraction) > 1e-5) {
         FCS_MSG_WARNING("bin content is negative in histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " binval=" << binval << " " << fraction * 100

--- a/source/Core/TFCS1DFunctionInt32Histogram.cxx
+++ b/source/Core/TFCS1DFunctionInt32Histogram.cxx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS1DFunctionInt32Histogram.h"
@@ -29,7 +30,7 @@ void TFCS1DFunctionInt32Histogram::Initialize(const TH1* hist)
     if (binval < 0) {
       // Can't work if a bin is negative, forcing bins to 0 in this case
       double fraction = binval / hist->Integral();
-      if (TMath::Abs(fraction) > 1e-5) {
+      if (std::abs(fraction) > 1e-5) {
         FCS_MSG_WARNING("bin content is negative in histogram "
                         << hist->GetName() << " : " << hist->GetTitle()
                         << " binval=" << binval << " " << fraction * 100

--- a/source/Core/TFCS2DFunctionHistogram.cxx
+++ b/source/Core/TFCS2DFunctionHistogram.cxx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCS2DFunctionHistogram.h"
@@ -28,7 +29,7 @@ void TFCS2DFunctionHistogram::Initialize(TH2* hist)
       if (binval < 0) {
         // Can't work if a bin is negative, forcing bins to 0 in this case
         double fraction = binval / hist->Integral();
-        if (TMath::Abs(fraction) > 1e-5) {
+        if (std::abs(fraction) > 1e-5) {
           FCS_MSG_WARNING("bin content is negative in histogram "
                           << hist->GetName() << " : " << hist->GetTitle()
                           << " binval=" << binval << " " << fraction * 100

--- a/source/Core/TFCS2DFunctionLateralShapeParametrization.cxx
+++ b/source/Core/TFCS2DFunctionLateralShapeParametrization.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCS2DFunctionLateralShapeParametrization.h"
 
 #include "CLHEP/Random/RandFlat.h"
@@ -113,8 +115,8 @@ auto TFCS2DFunctionLateralShapeParametrization::simulate_hit(
     return FCSFatal;
   }
 
-  float delta_eta_mm = r * cos(alpha);
-  float delta_phi_mm = r * sin(alpha);
+  float delta_eta_mm = r * std::cos(alpha);
+  float delta_phi_mm = r * std::sin(alpha);
 
   // Particles with negative eta are expected to have the same shape as those
   // with positive eta after transformation: delta_eta --> -delta_eta
@@ -126,9 +128,9 @@ auto TFCS2DFunctionLateralShapeParametrization::simulate_hit(
   if ((charge < 0. && pdgId != 11) || pdgId == -11)
     delta_phi_mm = -delta_phi_mm;
 
-  const float dist000 = TMath::Sqrt(center_r * center_r + center_z * center_z);
-  const float eta_jakobi = TMath::Abs(2.0 * TMath::Exp(-center_eta)
-                                      / (1.0 + TMath::Exp(-2 * center_eta)));
+  const float dist000 = std::sqrt(center_r * center_r + center_z * center_z);
+  const float eta_jakobi =
+      std::abs(2.0 * std::exp(-center_eta) / (1.0 + std::exp(-2 * center_eta)));
 
   const float delta_eta = delta_eta_mm / eta_jakobi / dist000;
   const float delta_phi = delta_phi_mm / center_r;

--- a/source/Core/TFCSBinnedShower.cxx
+++ b/source/Core/TFCSBinnedShower.cxx
@@ -154,7 +154,7 @@ auto TFCSBinnedShower::find_best_match(float eta_center,
       float phi_diff = (phi_mod - phi_within_cell) / phi_cell_size;
       dist2 = dist2 + phi_diff * phi_diff;
     }
-    float distance = TMath::Sqrt(dist2);
+    float distance = std::sqrt(dist2);
 
     if (distance < best_distance) {
       best_distance = distance;
@@ -373,7 +373,7 @@ auto TFCSBinnedShower::get_coordinates(TFCSSimulationState& simulstate,
         simulstate, R_min, R_max, alpha_min, alpha_max, layer_index, bin_index);
   }
   float R;
-  if (TMath::Abs(R_max - R_min) > std::numeric_limits<float>::epsilon()) {
+  if (std::abs(R_max - R_min) > std::numeric_limits<float>::epsilon()) {
     R = CLHEP::RandFlat::shoot(simulstate.randomEngine(), R_min, R_max);
   } else {
     R = R_min;  // If the range is too small, just use the minimum value
@@ -473,20 +473,20 @@ void TFCSBinnedShower::upscale(TFCSSimulationState& simulstate,
     p_r = 0.25;  // Values below 0.25 are not allowed for linear pdf
   } else if (p_r > 0.75) {
     p_r = 0.75;  // Values above 0.75 are not allowed for linear pdf
-  } else if (TMath::Abs(p_r - 0.5) < std::numeric_limits<float>::epsilon()) {
+  } else if (std::abs(p_r - 0.5) < std::numeric_limits<float>::epsilon()) {
     return;  // Best upscaling is uniform sampling. Nothing to do here.
   }
 
   // Inverse CDF for linear pdf
   float r = (1. - 4. * p_r) / (2. - 4. * p_r)
-      - TMath::Sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
-                        * ((1. - 4. * p_r) / (2. - 4. * p_r))
-                    + p / ((1. / 2.) - p_r));
+      - std::sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
+                      * ((1. - 4. * p_r) / (2. - 4. * p_r))
+                  + p / ((1. / 2.) - p_r));
   if (r < 0) {
     r = (1. - 4. * p_r) / (2. - 4. * p_r)
-        + TMath::Sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
-                          * ((1. - 4. * p_r) / (2. - 4. * p_r))
-                      + p / ((1. / 2.) - p_r));
+        + std::sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
+                        * ((1. - 4. * p_r) / (2. - 4. * p_r))
+                    + p / ((1. / 2.) - p_r));
   }
 
   R_min = R_min + r / 2 * (R_max - R_min);

--- a/source/Core/TFCSBinnedShowerBase.cxx
+++ b/source/Core/TFCSBinnedShowerBase.cxx
@@ -105,9 +105,9 @@ auto TFCSBinnedShowerBase::simulate_hit(
   FCS_MSG_VERBOSE(" Layer " << layer_index << " Extrap eta " << center_eta
                             << " phi " << center_phi << " R " << center_r);
 
-  const float dist000 = TMath::Sqrt(center_r * center_r + center_z * center_z);
-  const float eta_jakobi = TMath::Abs(2.0 * TMath::Exp(-center_eta)
-                                      / (1.0 + TMath::Exp(-2 * center_eta)));
+  const float dist000 = std::sqrt(center_r * center_r + center_z * center_z);
+  const float eta_jakobi =
+      std::abs(2.0 * std::exp(-center_eta) / (1.0 + std::exp(-2 * center_eta)));
 
   long unsigned int hit_index = hit.idx();
 

--- a/source/Core/TFCSBinnedShowerONNX.cxx
+++ b/source/Core/TFCSBinnedShowerONNX.cxx
@@ -443,20 +443,20 @@ void TFCSBinnedShowerONNX::upscale(TFCSSimulationState& simulstate,
     p_r = 0.25;  // Values below 0.25 are not allowed for linear pdf
   } else if (p_r > 0.75) {
     p_r = 0.75;  // Values above 0.75 are not allowed for linear pdf
-  } else if (TMath::Abs(p_r - 0.5) < std::numeric_limits<float>::epsilon()) {
+  } else if (std::abs(p_r - 0.5) < std::numeric_limits<float>::epsilon()) {
     return;  // Best upscaling is uniform sampling. Nothing to do here.
   }
 
   // Inverse CDF for linear pdf
   float r = (1. - 4. * p_r) / (2. - 4. * p_r)
-      - TMath::Sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
-                        * ((1. - 4. * p_r) / (2. - 4. * p_r))
-                    + p / ((1. / 2.) - p_r));
+      - std::sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
+                      * ((1. - 4. * p_r) / (2. - 4. * p_r))
+                  + p / ((1. / 2.) - p_r));
   if (r < 0) {
     r = (1. - 4. * p_r) / (2. - 4. * p_r)
-        + TMath::Sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
-                          * ((1. - 4. * p_r) / (2. - 4. * p_r))
-                      + p / ((1. / 2.) - p_r));
+        + std::sqrt(((1. - 4. * p_r) / (2. - 4. * p_r))
+                        * ((1. - 4. * p_r) / (2. - 4. * p_r))
+                    + p / ((1. / 2.) - p_r));
   }
 
   R_min = R_min + r / 2 * (R_max - R_min);

--- a/source/Core/TFCSEnergyAndHitGANV2.cxx
+++ b/source/Core/TFCSEnergyAndHitGANV2.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 
@@ -15,6 +17,7 @@
 #include "FastCaloSim/Definitions/ParticleData.h"
 #include "FastCaloSim/Geometry/CaloGeo.h"
 #include "TF1.h"
+#include "TMath.h"
 
 //=============================================
 //======= TFCSEnergyAndHitGANV2 =========
@@ -244,8 +247,8 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
       const int bin = get_bin(simulstate, truth, extrapol);
       if (bin >= 0 && bin < (int)get_number_of_bins()) {
         for (unsigned int ichain = m_bin_start[bin];
-             ichain < TMath::Min(m_bin_start[bin] + get_nr_of_init(bin),
-                                 m_bin_start[bin + 1]);
+             ichain < std::min(m_bin_start[bin] + get_nr_of_init(bin),
+                               m_bin_start[bin + 1]);
              ++ichain)
         {
           FCS_MSG_DEBUG("for " << get_variable_text(simulstate, truth, extrapol)
@@ -296,10 +299,9 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
     FCS_MSG_VERBOSE(" Layer " << layer << " Extrap eta " << center_eta
                               << " phi " << center_phi << " R " << center_r);
 
-    const float dist000 =
-        TMath::Sqrt(center_r * center_r + center_z * center_z);
-    const float eta_jakobi = TMath::Abs(2.0 * TMath::Exp(-center_eta)
-                                        / (1.0 + TMath::Exp(-2 * center_eta)));
+    const float dist000 = std::sqrt(center_r * center_r + center_z * center_z);
+    const float eta_jakobi = std::abs(2.0 * std::exp(-center_eta)
+                                      / (1.0 + std::exp(-2 * center_eta)));
 
     int nHitsAlpha {};
     int nHitsR {};
@@ -335,14 +337,14 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
           if (yBinNum == 1) {
             // nbins in alpha depend on circumference length
             const double r = x->GetBinUpEdge(ix);
-            nHitsAlpha = ceil(2 * TMath::Pi() * r / binResolution);
+            nHitsAlpha = std::ceil(2 * TMath::Pi() * r / binResolution);
           } else {
             // d = 2*r*sin (a/2r) this distance at the upper r must be 1mm for
             // layer 1 or 5, 5mm otherwise.
             const double angle = y->GetBinUpEdge(iy) - y->GetBinLowEdge(iy);
             const double r = x->GetBinUpEdge(ix);
-            const double d = 2 * r * sin(angle / 2 * r);
-            nHitsAlpha = ceil(d / binResolution);
+            const double d = 2 * r * std::sin(angle / 2 * r);
+            nHitsAlpha = std::ceil(d / binResolution);
           }
 
           if (layer != 1 && layer != 5) {
@@ -367,7 +369,7 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
                                                   x->GetBinLowEdge(ix),
                                                   x->GetBinUpEdge(ix));
                 double rand_r =
-                    log((a - x->GetBinLowEdge(ix)) / (x->GetBinWidth(ix)))
+                    std::log((a - x->GetBinLowEdge(ix)) / (x->GetBinWidth(ix)))
                     / fitResults.at(layer)[ix - 1];
                 while ((rand_r < x->GetBinLowEdge(ix)
                         || rand_r > x->GetBinUpEdge(ix))
@@ -376,8 +378,8 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
                   a = CLHEP::RandFlat::shoot(simulstate.randomEngine(),
                                              x->GetBinLowEdge(ix),
                                              x->GetBinUpEdge(ix));
-                  rand_r =
-                      log((a - x->GetBinLowEdge(ix)) / (x->GetBinWidth(ix)))
+                  rand_r = std::log((a - x->GetBinLowEdge(ix))
+                                    / (x->GetBinWidth(ix)))
                       / fitResults.at(layer)[ix - 1];
                   tries++;
                 }
@@ -416,8 +418,8 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
             hit.set_E(Einit * energyInVoxel / (nHitsAlpha * nHitsR));
 
             if (layer <= 20) {
-              float delta_eta_mm = r * cos(alpha);
-              float delta_phi_mm = r * sin(alpha);
+              float delta_eta_mm = r * std::cos(alpha);
+              float delta_phi_mm = r * std::sin(alpha);
 
               FCS_MSG_VERBOSE("delta_eta_mm " << delta_eta_mm
                                               << " delta_phi_mm "
@@ -444,8 +446,8 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
               FCS_MSG_VERBOSE(" Hit eta " << hit.eta() << " phi " << hit.phi()
                                           << " layer " << layer);
             } else {  // FCAL is in (x,y,z)
-              const float hit_r = r * cos(alpha) + center_r;
-              float delta_phi = r * sin(alpha) / center_r;
+              const float hit_r = r * std::cos(alpha) + center_r;
+              float delta_phi = r * std::sin(alpha) / center_r;
               // We derive the shower shapes for electrons and positively
               // charged hadrons. Particle with the opposite charge are expected
               // to have the same shower shape after the transformation:
@@ -454,8 +456,8 @@ auto TFCSEnergyAndHitGANV2::fillEnergy(
                 delta_phi = -delta_phi;
               const float hit_phi =
                   TVector2::Phi_mpi_pi(center_phi + delta_phi);
-              hit.set_eta_x(hit_r * cos(hit_phi));
-              hit.set_phi_y(hit_r * sin(hit_phi));
+              hit.set_eta_x(hit_r * std::cos(hit_phi));
+              hit.set_phi_y(hit_r * std::sin(hit_phi));
               hit.set_z(center_z);
               FCS_MSG_VERBOSE(" Hit x " << hit.x() << " y " << hit.y()
                                         << " layer " << layer);

--- a/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
+++ b/source/Core/TFCSEnergyInterpolationPiecewiseLinear.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSEnergyInterpolationPiecewiseLinear.h"
 
 #include "FastCaloSim/Core/TFCSExtrapolationState.h"
@@ -42,7 +44,7 @@ void TFCSEnergyInterpolationPiecewiseLinear::InitFromArrayInEkin(
 {
   std::vector<Double_t> logEkin(np);
   for (int i = 0; i < np; i++)
-    logEkin[i] = TMath::Log(Ekin[i]);
+    logEkin[i] = std::log(Ekin[i]);
   InitFromArrayInLogEkin(np, logEkin.data(), response);
 }
 
@@ -56,9 +58,8 @@ auto TFCSEnergyInterpolationPiecewiseLinear::simulate(
 
   // catch very small values of Ekin (use 1 keV here) and fix the interpolation
   // lookup to the 1keV value
-  const float logEkin = Ekin > Gaudi::Units::keV
-      ? TMath::Log(Ekin)
-      : TMath::Log(Gaudi::Units::keV);
+  const float logEkin =
+      Ekin > Gaudi::Units::keV ? std::log(Ekin) : std::log(Gaudi::Units::keV);
 
   float Emean;
   if (logEkin < m_MinMaxlogEkin.first) {
@@ -95,9 +96,8 @@ auto TFCSEnergyInterpolationPiecewiseLinear::evaluate(const double& Ekin) const
 
   // catch very small values of Ekin (use 1 keV here) and fix the interpolation
   // lookup to the 1keV value
-  const float logEkin = Ekin > Gaudi::Units::keV
-      ? TMath::Log(Ekin)
-      : TMath::Log(Gaudi::Units::keV);
+  const float logEkin =
+      Ekin > Gaudi::Units::keV ? std::log(Ekin) : std::log(Gaudi::Units::keV);
 
   if (logEkin < m_MinMaxlogEkin.first)
     return m_linInterpol.Eval(m_MinMaxlogEkin.first);
@@ -122,8 +122,8 @@ void TFCSEnergyInterpolationPiecewiseLinear::Print(Option_t* option) const
                           << "linInterpol N=" << m_logEkin.size() << " "
                           << m_MinMaxlogEkin.first
                           << "<=log(Ekin)<=" << m_MinMaxlogEkin.second << " "
-                          << TMath::Exp(m_MinMaxlogEkin.first)
-                          << "<=Ekin<=" << TMath::Exp(m_MinMaxlogEkin.second));
+                          << std::exp(m_MinMaxlogEkin.first)
+                          << "<=Ekin<=" << std::exp(m_MinMaxlogEkin.second));
 }
 
 void TFCSEnergyInterpolationPiecewiseLinear::Streamer(TBuffer& R__b)

--- a/source/Core/TFCSEnergyInterpolationSpline.cxx
+++ b/source/Core/TFCSEnergyInterpolationSpline.cxx
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
 #include <iostream>
 #include <vector>
 
@@ -46,7 +47,7 @@ void TFCSEnergyInterpolationSpline::InitFromArrayInEkin(Int_t np,
 {
   std::vector<Double_t> logEkin(np);
   for (int i = 0; i < np; ++i)
-    logEkin[i] = TMath::Log(Ekin[i]);
+    logEkin[i] = std::log(Ekin[i]);
   InitFromArrayInLogEkin(np, logEkin.data(), response, opt, valbeg, valend);
 }
 
@@ -65,8 +66,7 @@ auto TFCSEnergyInterpolationSpline::simulate(
   // catch very small values of Ekin (use 1 keV here) and fix the spline lookup
   // to the 1keV value
   const float logEkin =
-      (Ekin > Gaudi::Units::keV ? TMath::Log(Ekin)
-                                : TMath::Log(Gaudi::Units::keV));
+      (Ekin > Gaudi::Units::keV ? std::log(Ekin) : std::log(Gaudi::Units::keV));
   if (logEkin < m_spline.GetXmin()) {
     Emean = m_spline.Eval(m_spline.GetXmin()) * Einit;
   } else {
@@ -106,6 +106,6 @@ void TFCSEnergyInterpolationSpline::Print(Option_t* option) const
                           << "Spline N=" << m_spline.GetNp() << " "
                           << m_spline.GetXmin()
                           << "<=log(Ekin)<=" << m_spline.GetXmax() << " "
-                          << TMath::Exp(m_spline.GetXmin())
-                          << "<=Ekin<=" << TMath::Exp(m_spline.GetXmax()));
+                          << std::exp(m_spline.GetXmin())
+                          << "<=Ekin<=" << std::exp(m_spline.GetXmax()));
 }

--- a/source/Core/TFCSFlatLateralShapeParametrization.cxx
+++ b/source/Core/TFCSFlatLateralShapeParametrization.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSFlatLateralShapeParametrization.h"
 
 #include "CLHEP/Random/RandFlat.h"
@@ -79,8 +81,8 @@ auto TFCSFlatLateralShapeParametrization::simulate_hit(
   alpha = 2 * TMath::Pi() * CLHEP::RandFlat::shoot(simulstate.randomEngine());
   r = m_dR * CLHEP::RandFlat::shoot(simulstate.randomEngine());
 
-  float delta_eta = r * cos(alpha);
-  float delta_phi = r * sin(alpha);
+  float delta_eta = r * std::cos(alpha);
+  float delta_phi = r * std::sin(alpha);
 
   hit.setEtaPhiZE(center_eta + delta_eta,
                   center_phi + delta_phi,

--- a/source/Core/TFCSHistoLateralShapeParametrizationFCal.cxx
+++ b/source/Core/TFCSHistoLateralShapeParametrizationFCal.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSHistoLateralShapeParametrizationFCal.h"
 
 #include "CLHEP/Random/RandFlat.h"
@@ -75,8 +77,8 @@ auto TFCSHistoLateralShapeParametrizationFCal::simulate_hit(
     return FCSFatal;
   }
 
-  const float hit_r = r * cos(alpha) + center_r;
-  float delta_phi = r * sin(alpha) / center_r;
+  const float hit_r = r * std::cos(alpha) + center_r;
+  float delta_phi = r * std::sin(alpha) / center_r;
   // We derive the shower shapes for electrons and positively charged hadrons.
   // Particle with the opposite charge are expected to have the same shower
   // shape after the transformation: delta_phi --> -delta_phi
@@ -84,7 +86,8 @@ auto TFCSHistoLateralShapeParametrizationFCal::simulate_hit(
     delta_phi = -delta_phi;
   const float hit_phi = delta_phi + center_phi;
 
-  hit.setXYZE(hit_r * cos(hit_phi), hit_r * sin(hit_phi), center_z, hit.E());
+  hit.setXYZE(
+      hit_r * std::cos(hit_phi), hit_r * std::sin(hit_phi), center_z, hit.E());
 
   FCS_MSG_DEBUG("HIT: E=" << hit.E() << " cs=" << cs << " x=" << hit.x()
                           << " y=" << hit.y() << " z=" << hit.z() << " r=" << r

--- a/source/Core/TFCSHitCellMappingWiggle.cxx
+++ b/source/Core/TFCSHitCellMappingWiggle.cxx
@@ -3,6 +3,8 @@
 
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSHitCellMappingWiggle.h"
 
 #include <TClass.h>
@@ -124,7 +126,7 @@ auto TFCSHitCellMappingWiggle::simulate_hit(
     return FCSFatal;
   }
 
-  float eta = fabs(hit.eta());
+  float eta = std::fabs(hit.eta());
   if (eta < m_bin_low_edge[0] || eta >= m_bin_low_edge[get_number_of_bins()]) {
     return TFCSHitCellMapping::simulate_hit(hit, simulstate, truth, extrapol);
   }

--- a/source/Core/TFCSLateralShapeParametrizationHitNumberFromE.cxx
+++ b/source/Core/TFCSLateralShapeParametrizationHitNumberFromE.cxx
@@ -2,6 +2,8 @@
 #pragma GCC diagnostic ignored "-Wfloat-equal"
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSLateralShapeParametrizationHitNumberFromE.h"
 
 #include <TClass.h>
@@ -58,7 +60,7 @@ auto TFCSLateralShapeParametrizationHitNumberFromE::get_sigma2_fluctuation(
     return 1;
   }
 
-  double sqrtE = sqrt(energy / 1000.0);
+  double sqrtE = std::sqrt(energy / 1000.0);
   double sigma_stochastic = m_stochastic / sqrtE;
   double sigma_stochastic_hadron = m_stochastic_hadron / sqrtE;
 

--- a/source/Core/TFCSParametrizationAbsEtaSelectChain.cxx
+++ b/source/Core/TFCSParametrizationAbsEtaSelectChain.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSParametrizationAbsEtaSelectChain.h"
 
 #include "FastCaloSim/Core/TFCSExtrapolationState.h"
@@ -15,7 +17,7 @@ auto TFCSParametrizationAbsEtaSelectChain::get_bin(
     const TFCSTruthState*,
     const TFCSExtrapolationState* extrapol) const -> int
 {
-  return val_to_bin(TMath::Abs(extrapol->IDCaloBoundary_eta()));
+  return val_to_bin(std::abs(extrapol->IDCaloBoundary_eta()));
 }
 
 auto TFCSParametrizationAbsEtaSelectChain::get_bin_text(int bin) const

--- a/source/Core/TFCSParametrizationEkinSelectChain.cxx
+++ b/source/Core/TFCSParametrizationEkinSelectChain.cxx
@@ -1,5 +1,6 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
 #include <iostream>
 
 #include "FastCaloSim/Core/TFCSParametrizationEkinSelectChain.h"
@@ -72,9 +73,9 @@ auto TFCSParametrizationEkinSelectChain::get_bin(
     if (!first_in_prevbin)
       return bin;
 
-    float logEkin = TMath::Log(Ekin);
-    float logEkin_nominal = TMath::Log(first_in_bin->Ekin_nominal());
-    float logEkin_previous = TMath::Log(first_in_prevbin->Ekin_nominal());
+    float logEkin = std::log(Ekin);
+    float logEkin_nominal = std::log(first_in_bin->Ekin_nominal());
+    float logEkin_previous = std::log(first_in_prevbin->Ekin_nominal());
     float numerator = logEkin - logEkin_previous;
     float denominator = logEkin_nominal - logEkin_previous;
     if (denominator <= 0)
@@ -100,9 +101,9 @@ auto TFCSParametrizationEkinSelectChain::get_bin(
     if (!first_in_nextbin)
       return bin;
 
-    float logEkin = TMath::Log(Ekin);
-    float logEkin_nominal = TMath::Log(first_in_bin->Ekin_nominal());
-    float logEkin_next = TMath::Log(first_in_nextbin->Ekin_nominal());
+    float logEkin = std::log(Ekin);
+    float logEkin_nominal = std::log(first_in_bin->Ekin_nominal());
+    float logEkin_next = std::log(first_in_nextbin->Ekin_nominal());
     float numerator = logEkin - logEkin_nominal;
     float denominator = logEkin_next - logEkin_nominal;
     if (denominator <= 0)

--- a/source/Core/TFCSPhiModulationCorrection.cxx
+++ b/source/Core/TFCSPhiModulationCorrection.cxx
@@ -9,10 +9,11 @@
 #include "FastCaloSim/Geometry/CaloGeo.h"
 
 // External includes
+#include <cmath>
+
 #include <RtypesCore.h>
 #include <TFile.h>
 #include <TH2F.h>
-#include <TMath.h>
 #include <TParameter.h>
 
 //=============================================
@@ -151,7 +152,7 @@ auto TFCSPhiModulationCorrection::get_eta_and_phi_index(
     float phi, float eta, long unsigned int layer_index) const
     -> std::tuple<int, long unsigned int, long unsigned int>
 {
-  float eta_abs = TMath::Abs(eta);
+  float eta_abs = std::abs(eta);
 
   auto eta_it = std::upper_bound(m_min_eta.at(layer_index).begin(),
                                  m_min_eta.at(layer_index).end(),
@@ -200,7 +201,7 @@ auto TFCSPhiModulationCorrection::get_eta_and_phi_index(
 
   float phi_cell_size = get_phi_cell_size(layer_index, eta);
 
-  phi_within_cell = fmod(phi_within_cell, phi_cell_size);
+  phi_within_cell = std::fmod(phi_within_cell, phi_cell_size);
 
   if (phi_within_cell < 0)
     phi_within_cell += phi_cell_size;

--- a/source/Core/TFCSVoxelHistoLateralCovarianceFluctuations.cxx
+++ b/source/Core/TFCSVoxelHistoLateralCovarianceFluctuations.cxx
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 CERN for the benefit of the FastCaloSim project
 
+#include <cmath>
+
 #include "FastCaloSim/Core/TFCSVoxelHistoLateralCovarianceFluctuations.h"
 
 #include "CLHEP/Random/RandFlat.h"
@@ -157,10 +159,10 @@ void TFCSVoxelHistoLateralCovarianceFluctuations::MultiGaus(
       variance = 0;
     }
     genPars[iPar] = CLHEP::RandGauss::shoot(
-        simulstate.randomEngine(), rotParMeans[iPar], sqrt(variance));
+        simulstate.randomEngine(), rotParMeans[iPar], std::sqrt(variance));
     FCS_MSG_DEBUG("genPars[" << iPar << "]=" << genPars[iPar]
                              << " rotParMeans[iPar]=" << rotParMeans[iPar]
-                             << " sqrt(variance)=" << sqrt(variance));
+                             << " sqrt(variance)=" << std::sqrt(variance));
   }
   genPars = m_EigenVectors[Ebin - 1] * genPars;
 }
@@ -338,9 +340,9 @@ auto TFCSVoxelHistoLateralCovarianceFluctuations::simulate_hit(
     deta_hit_minus_extrapol = -deta_hit_minus_extrapol;
 
   float phi_dist2r = 1.0;
-  float dist000 = TMath::Sqrt(center_r * center_r + center_z * center_z);
-  float eta_jakobi = TMath::Abs(2.0 * TMath::Exp(-hit.eta())
-                                / (1.0 + TMath::Exp(-2 * hit.eta())));
+  float dist000 = std::sqrt(center_r * center_r + center_z * center_z);
+  float eta_jakobi =
+      std::abs(2.0 * std::exp(-hit.eta()) / (1.0 + std::exp(-2 * hit.eta())));
 
   float deta_hit_minus_extrapol_mm =
       deta_hit_minus_extrapol * eta_jakobi * dist000;
@@ -348,10 +350,10 @@ auto TFCSVoxelHistoLateralCovarianceFluctuations::simulate_hit(
       dphi_hit_minus_extrapol * center_r * phi_dist2r;
 
   float alpha_mm =
-      TMath::ATan2(dphi_hit_minus_extrapol_mm, deta_hit_minus_extrapol_mm);
+      std::atan2(dphi_hit_minus_extrapol_mm, deta_hit_minus_extrapol_mm);
   float radius_mm =
-      TMath::Sqrt(dphi_hit_minus_extrapol_mm * dphi_hit_minus_extrapol_mm
-                  + deta_hit_minus_extrapol_mm * deta_hit_minus_extrapol_mm);
+      std::sqrt(dphi_hit_minus_extrapol_mm * dphi_hit_minus_extrapol_mm
+                + deta_hit_minus_extrapol_mm * deta_hit_minus_extrapol_mm);
 
   int ix;
   int iy = voxel_template->GetYaxis()->FindBin(radius_mm) - 1;
@@ -361,7 +363,8 @@ auto TFCSVoxelHistoLateralCovarianceFluctuations::simulate_hit(
     ix = 0;
   } else {
     if (alpha_mm < 0)
-      ix = voxel_template->GetXaxis()->FindBin(2 * TMath::Pi() - fabs(alpha_mm))
+      ix = voxel_template->GetXaxis()->FindBin(2 * TMath::Pi()
+                                               - std::fabs(alpha_mm))
           - 1;
     else
       ix = voxel_template->GetXaxis()->FindBin(alpha_mm) - 1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized mathematical calculations across simulation, histogram, interpolation, geometry, and shower-processing components.
  * Replaced legacy and unqualified math utilities with consistent C++ standard-library equivalents.
  * Preserved existing behavior, public interfaces, and numerical processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->